### PR TITLE
add ch32x035

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Please visit https://pio-ch32v.readthedocs.io/ for the most recent documention.
     - [x] CH32V303 (QingKe V4F)
     - [x] CH32V305 (QingKe V4F)
     - [x] CH32V307 (QingKe V4F)
+    - [x] CH32X035 (QingKe V4C)
     - [x] CH56x (QingKe V3A)
     - [x] CH57x (QingKe V3A)
     - [x] CH58x (QingKe V4A)
@@ -38,6 +39,7 @@ Please visit https://pio-ch32v.readthedocs.io/ for the most recent documention.
     - [x] CH32V003F4P6-EVT-R0 (official by W.CH)
     - [x] CH32V203C8T6-EVT-R0 (official by W.CH)
     - [x] CH32V307 EVT (by SCDZ, close to official W.CH board)
+    - [x] CH32X035C8T6-EVT-R0, CH32X035G8U6-EVT-R0, CH32X035F8U6-EVT-R0  (official by W.CH)
 - frameworks
     - [x] None OS ("Simple Peripheral Library" / native SDK)
     - [ ] Arduino

--- a/boards/ch32x035c8t6_evt_r0.json
+++ b/boards/ch32x035c8t6_evt_r0.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035c8t6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "CH32X035C8T6-EVT-R0",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/ch32x035f8u6_evt_r0.json
+++ b/boards/ch32x035f8u6_evt_r0.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035f8u6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "CH32X035F8U6-EVT-R0",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/ch32x035g8u6_evt_r0.json
+++ b/boards/ch32x035g8u6_evt_r0.json
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "CH32X035G8U6-EVT-R0",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/genericCH32X035C8T8.json
+++ b/boards/genericCH32X035C8T8.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035c8t6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035C8T6",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/genericCH32X035F7P6.json
+++ b/boards/genericCH32X035F7P6.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035f7p6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,10 +23,10 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035F7P6",
   "upload": {
     "maximum_ram_size": 20480,
-    "maximum_size": 63488,
+    "maximum_size": 43008,
     "protocols": [
       "wch-link",
       "minichlink",

--- a/boards/genericCH32X035F8P6.json
+++ b/boards/genericCH32X035F8P6.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035f8p6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035F8P6",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/genericCH32X035F8U6.json
+++ b/boards/genericCH32X035F8U6.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035f8u6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035F8U6",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/genericCH32X035G8R6.json
+++ b/boards/genericCH32X035G8R6.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035g8r6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035G8R6",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/boards/genericCH32X035G8U6.json
+++ b/boards/genericCH32X035G8U6.json
@@ -1,0 +1,39 @@
+{
+  "build": {
+    "f_cpu": "144000000L",
+    "extra_flags": "-DCH32X035G6 -DCH32X035",
+    "hwids": [
+      [
+        "0x1A86",
+        "0x8010"
+      ]
+    ],
+    "mabi": "ilp32",
+    "march": "rv32imacxw",
+    "mcu": "ch32x035g8u6",
+    "series": "ch32x035"
+  },
+  "debug": {
+    "onboard_tools": [
+      "wch-link"
+    ],
+    "openocd_config": "wch-riscv.cfg",
+    "svd_path": "CH32X035.svd"
+  },
+  "frameworks": [
+    "noneos-sdk"
+  ],
+  "name": "Generic CH32X035G8U6",
+  "upload": {
+    "maximum_ram_size": 20480,
+    "maximum_size": 65536,
+    "protocols": [
+      "wch-link",
+      "minichlink",
+      "isp"
+    ],
+    "protocol": "wch-link"
+  },
+  "url": "http://www.wch-ic.com/products/CH32X035.html",
+  "vendor": "W.CH"
+}

--- a/boards/genericCH32X035R8T6.json
+++ b/boards/genericCH32X035R8T6.json
@@ -10,7 +10,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imacxw",
-    "mcu": "ch32x035g8u6",
+    "mcu": "ch32x035r8t6",
     "series": "ch32x035"
   },
   "debug": {
@@ -23,7 +23,7 @@
   "frameworks": [
     "noneos-sdk"
   ],
-  "name": "Generic CH32X035G8U6",
+  "name": "Generic CH32X035R8T6",
   "upload": {
     "maximum_ram_size": 20480,
     "maximum_size": 63488,

--- a/builder/frameworks/noneos_sdk.py
+++ b/builder/frameworks/noneos_sdk.py
@@ -6,7 +6,10 @@ env = DefaultEnvironment()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 # convert MCU name (e.g. "ch32v307") to series (e.g. "ch32v30x")
-chip_series: str = board.get("build.series", "")[0:-1].lower() + "x"
+if board.get("build.series", "") in ("ch32x035"):
+    chip_series: str = board.get("build.series", "")
+else:
+    chip_series = board.get("build.series", "")[0:-1].lower() + "x"
 # import default build settings
 env.SConscript("_bare.py")
 
@@ -69,7 +72,8 @@ def get_startup_filename(board):
         "CH32V20x_D8": "startup_ch32v20x_D8.S",
         "CH32V20x_D8W": "startup_ch32v20x_D8W.S",
         "CH32V30x_D8": "startup_ch32v30x_D8.S",
-        "CH32V30x_D8C": "startup_ch32v30x_D8C.S"
+        "CH32V30x_D8C": "startup_ch32v30x_D8C.S",
+        "CH32X035": "startup_ch32x035.S",
     }
     startup_file = None
     for k, v in class_to_startup.items():

--- a/misc/svd/CH32X035.svd
+++ b/misc/svd/CH32X035.svd
@@ -1,0 +1,13870 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>WCH Ltd.</vendor><!-- device vendor name -->
+  <vendorID>WCH</vendorID><!-- device vendor short name -->
+  <name>CH32X035</name>
+  <version>1.0</version>
+  <description>CH32X035 View File</description><!--Bus Interface Properties--><!--RISC-V is byte addressable-->
+  <addressUnitBits>8</addressUnitBits><!--the maximum data bit width accessible within a single transfer-->
+  <width>32</width><!--Register Default Properties-->
+  <size>0x20</size>
+  <resetValue>0x0</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>PWR</name>
+      <description>Power control</description>
+      <groupName>PWR</groupName>
+      <baseAddress>0x40007000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PVD</name>
+        <description>PVD through EXTI line detection
+        interrupt</description>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>Power control register
+          (PWR_CTLR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PDDS</name>
+              <description>Power Down Deep Sleep</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PLS</name>
+              <description>PVD Level Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LP_REG</name>
+              <description>LP_REG enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LP</name>
+              <description>LP Config</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>			  
+            </field>
+            
+          </fields>
+        </register>
+        <register>
+          <name>CSR</name>
+          <displayName>CSR</displayName>
+          <description>Power control register
+          (PWR_CSR)</description>
+          <addressOffset>0x04</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+
+            <field>
+              <name>PVDO</name>
+              <description>PVD Output</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>Flash_ackck</name>
+              <description>Flash Status flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>RCC</name>
+      <description>Reset and clock control</description>
+      <groupName>RCC</groupName>
+      <baseAddress>0x40021000</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000083</resetValue>
+          <fields>
+            <field>
+              <name>HSION</name>
+              <description>Internal High Speed clock
+              enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSIRDY</name>
+              <description>Internal High Speed clock ready
+              flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>HSITRIM</name>
+              <description>Internal High Speed clock
+              trimming</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HSICAL</name>
+              <description>Internal High Speed clock
+              Calibration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            
+          </fields>
+        </register>
+        <register>
+          <name>CFGR0</name>
+          <displayName>CFGR0</displayName>
+          <description>Clock configuration register
+          (RCC_CFGR0)</description>
+          <addressOffset>0x04</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            
+            <field>
+              <name>HPRE</name>
+              <description>AHB prescaler</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>MCO</name>
+              <description>Microcontroller clock
+              output</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            
+          </fields>
+        </register>
+
+        <register>
+          <name>APB2PRSTR</name>
+          <displayName>APB2PRSTR</displayName>
+          <description>APB2 peripheral reset register
+          (RCC_APB2PRSTR)</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFIORST</name>
+              <description>Alternate function I/O
+              reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>			  
+            </field>
+            <field>
+              <name>IOPARST</name>
+              <description>IO port A reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IOPBRST</name>
+              <description>IO port B reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IOPCRST</name>
+              <description>IO port C reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ADC1RST</name>
+              <description>ADC 1 interface reset</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>TIM1RST</name>
+              <description>TIM1 timer reset</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SPI1RST</name>
+              <description>SPI 1 reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+           
+            <field>
+              <name>USART1RST</name>
+              <description>USART1 reset</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            </fields>
+        </register>
+        <register>
+          <name>APB1PRSTR</name>
+          <displayName>APB1PRSTR</displayName>
+          <description>APB1 peripheral reset register
+          (RCC_APB1PRSTR)</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TIM2RST</name>
+              <description>Timer 2 reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM3RST</name>
+              <description>Timer 3 reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>WWDGRST</name>
+              <description>Window watchdog reset</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>USART2RST</name>
+              <description>USART 2 reset</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USART3RST</name>
+              <description>USART 3 reset</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USART4RST</name>
+              <description>USART 4 reset</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+
+            <field>
+              <name>I2C1RST</name>
+              <description>I2C1 reset</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+           
+            <field>
+              <name>PWRRST</name>
+              <description>Power interface reset</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBPCENR</name>
+          <displayName>AHBPCENR</displayName>
+          <description>AHB Peripheral Clock enable register
+          (RCC_AHBPCENR)</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000014</resetValue>
+          <fields>
+            <field>
+              <name>DMA1EN</name>
+              <description>DMA clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>SRAMEN</name>
+              <description>SRAM interface clock
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>USBFSEN</name>
+              <description>USBFS clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+
+            <field>
+              <name>USBPD</name>
+              <description>USBPD clock enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+          </fields>
+        </register>
+        <register>
+          <name>APB2PCENR</name>
+          <displayName>APB2PCENR</displayName>
+          <description>APB2 peripheral clock enable register
+          (RCC_APB2PCENR)</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AFIOEN</name>
+              <description>Alternate function I/O clock
+              enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IOPAEN</name>
+              <description>I/O port A clock enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IOPBEN</name>
+              <description>I/O port B clock enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IOPCEN</name>
+              <description>I/O port C clock enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>ADC1EN</name>
+              <description>ADC1 interface clock
+              enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM1EN</name>
+              <description>TIM1 Timer clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SPI1EN</name>
+              <description>SPI 1 clock enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USART1EN</name>
+              <description>USART1 clock enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+          </fields>
+        </register>
+        <register>
+          <name>APB1PCENR</name>
+          <displayName>APB1PCENR</displayName>
+          <description>APB1 peripheral clock enable register
+          (RCC_APB1PCENR)</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TIM2EN</name>
+              <description>Timer 2 clock enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM3EN</name>
+              <description>Timer 3 clock enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>WWDGEN</name>
+              <description>Window watchdog clock
+              enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>USART2EN</name>
+              <description>USART 2 clock enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USART3EN</name>
+              <description>USART 3 clock enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>UART4EN</name>
+              <description>UART 4 clock enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>I2C1EN</name>
+              <description>I2C 1 clock enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+           
+            <field>
+              <name>PWREN</name>
+              <description>Power interface clock
+              enable</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+
+          </fields>
+        </register>
+        
+        <register>
+          <name>RSTSCKR</name>
+          <displayName>RSTSCKR</displayName>
+          <description>Control/status register
+          (RCC_RSTSCKR)</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x0C000000</resetValue>
+          <fields>
+            
+            <field>
+              <name>RMVF</name>
+              <description>Remove reset flag</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>OPARSTF</name>
+              <description>OPA reset flag</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PINRSTF</name>
+              <description>PIN reset flag</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PORRSTF</name>
+              <description>POR/PDR reset flag</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SFTRSTF</name>
+              <description>Software reset flag</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IWDGRSTF</name>
+              <description>Independent watchdog reset
+              flag</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>WWDGRSTF</name>
+              <description>Window watchdog reset flag</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LPWRRSTF</name>
+              <description>Low-power reset flag</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBRSTR</name>
+          <displayName>AHBRSTR</displayName>
+          <description>AHB reset register
+          (RCC_APHBRSTR)</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>USBFSRST</name>
+              <description>USBFS reset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PIOCRST</name>
+              <description>PIOC reset</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>USBPDRST</name>
+              <description>USBPD reset</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        
+      </registers>
+    </peripheral>
+    
+    <peripheral>
+      <name>GPIOA</name>
+      <description>General purpose I/O</description>
+      <groupName>GPIO</groupName>
+      <baseAddress>0x40010800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGLR</name>
+          <displayName>CFGLR</displayName>
+          <description>Port configuration register low
+          (GPIOn_CFGLR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x44444444</resetValue>
+          <fields>
+            <field>
+              <name>MODE0</name>
+              <description>Port n.0 mode bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF0</name>
+              <description>Port n.0 configuration
+              bits</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>Port n.1 mode bits</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF1</name>
+              <description>Port n.1 configuration
+              bits</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>Port n.2 mode bits</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF2</name>
+              <description>Port n.2 configuration
+              bits</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>Port n.3 mode bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF3</name>
+              <description>Port n.3 configuration
+              bits</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE4</name>
+              <description>Port n.4 mode bits</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF4</name>
+              <description>Port n.4 configuration
+              bits</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE5</name>
+              <description>Port n.5 mode bits</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF5</name>
+              <description>Port n.5 configuration
+              bits</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE6</name>
+              <description>Port n.6 mode bits</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF6</name>
+              <description>Port n.6 configuration
+              bits</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE7</name>
+              <description>Port n.7 mode bits</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF7</name>
+              <description>Port n.7 configuration
+              bits</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGHR</name>
+          <displayName>CFGHR</displayName>
+          <description>Port configuration register high
+          (GPIOn_CFGHR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x44444444</resetValue>
+          <fields>
+            <field>
+              <name>MODE8</name>
+              <description>Port n.8 mode bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF8</name>
+              <description>Port n.8 configuration
+              bits</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE9</name>
+              <description>Port n.9 mode bits</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF9</name>
+              <description>Port n.9 configuration
+              bits</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE10</name>
+              <description>Port n.10 mode bits</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF10</name>
+              <description>Port n.10 configuration
+              bits</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE11</name>
+              <description>Port n.11 mode bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF11</name>
+              <description>Port n.11 configuration
+              bits</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE12</name>
+              <description>Port n.12 mode bits</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF12</name>
+              <description>Port n.12 configuration
+              bits</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE13</name>
+              <description>Port n.13 mode bits</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF13</name>
+              <description>Port n.13 configuration
+              bits</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE14</name>
+              <description>Port n.14 mode bits</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF14</name>
+              <description>Port n.14 configuration
+              bits</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE15</name>
+              <description>Port n.15 mode bits</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF15</name>
+              <description>Port n.15 configuration
+              bits</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INDR</name>
+          <displayName>INDR</displayName>
+          <description>Port input data register
+          (GPIOn_INDR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IDR0</name>
+              <description>Port input data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR1</name>
+              <description>Port input data</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR2</name>
+              <description>Port input data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR3</name>
+              <description>Port input data</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR4</name>
+              <description>Port input data</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR5</name>
+              <description>Port input data</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR6</name>
+              <description>Port input data</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR7</name>
+              <description>Port input data</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR8</name>
+              <description>Port input data</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR9</name>
+              <description>Port input data</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR10</name>
+              <description>Port input data</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR11</name>
+              <description>Port input data</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR12</name>
+              <description>Port input data</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR13</name>
+              <description>Port input data</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR14</name>
+              <description>Port input data</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>IDR15</name>
+              <description>Port input data</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR16</name>
+              <description>Port input data</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR17</name>
+              <description>Port input data</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR18</name>
+              <description>Port input data</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR19</name>
+              <description>Port input data</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR20</name>
+              <description>Port input data</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR21</name>
+              <description>Port input data</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR22</name>
+              <description>Port input data</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>IDR23</name>
+              <description>Port input data</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OUTDR</name>
+          <displayName>OUTDR</displayName>
+          <description>Port output data register
+          (GPIOn_OUTDR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>ODR0</name>
+              <description>Port output data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR1</name>
+              <description>Port output data</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR2</name>
+              <description>Port output data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR3</name>
+              <description>Port output data</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR4</name>
+              <description>Port output data</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR5</name>
+              <description>Port output data</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR6</name>
+              <description>Port output data</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR7</name>
+              <description>Port output data</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR8</name>
+              <description>Port output data</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR9</name>
+              <description>Port output data</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR10</name>
+              <description>Port output data</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR11</name>
+              <description>Port output data</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR12</name>
+              <description>Port output data</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR13</name>
+              <description>Port output data</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR14</name>
+              <description>Port output data</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ODR15</name>
+              <description>Port output data</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR16</name>
+              <description>Port output data</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR17</name>
+              <description>Port output data</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR18</name>
+              <description>Port output data</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR19</name>
+              <description>Port output data</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR20</name>
+              <description>Port output data</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR21</name>
+              <description>Port output data</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR22</name>
+              <description>Port output data</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ODR23</name>
+              <description>Port output data</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BSHR</name>
+          <displayName>BSHR</displayName>
+          <description>Port bit set/reset register
+          (GPIOn_BSHR)</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BS0</name>
+              <description>Set bit 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS1</name>
+              <description>Set bit 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS2</name>
+              <description>Set bit 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS3</name>
+              <description>Set bit 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS4</name>
+              <description>Set bit 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS5</name>
+              <description>Set bit 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS6</name>
+              <description>Set bit 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS7</name>
+              <description>Set bit 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS8</name>
+              <description>Set bit 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS9</name>
+              <description>Set bit 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS10</name>
+              <description>Set bit 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS11</name>
+              <description>Set bit 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS12</name>
+              <description>Set bit 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS13</name>
+              <description>Set bit 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS14</name>
+              <description>Set bit 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS15</name>
+              <description>Set bit 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR0</name>
+              <description>Reset bit 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Reset bit 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Reset bit 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Reset bit 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Reset bit 4</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Reset bit 5</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Reset bit 6</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Reset bit 7</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR8</name>
+              <description>Reset bit 8</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR9</name>
+              <description>Reset bit 9</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR10</name>
+              <description>Reset bit 10</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR11</name>
+              <description>Reset bit 11</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR12</name>
+              <description>Reset bit 12</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR13</name>
+              <description>Reset bit 13</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR14</name>
+              <description>Reset bit 14</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR15</name>
+              <description>Reset bit 15</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BCR</name>
+          <displayName>BCR</displayName>
+          <description>Port bit reset register
+          (GPIOn_BCR)</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BR0</name>
+              <description>Reset bit 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR1</name>
+              <description>Reset bit 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR2</name>
+              <description>Reset bit 1</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR3</name>
+              <description>Reset bit 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR4</name>
+              <description>Reset bit 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR5</name>
+              <description>Reset bit 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR6</name>
+              <description>Reset bit 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR7</name>
+              <description>Reset bit 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR8</name>
+              <description>Reset bit 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR9</name>
+              <description>Reset bit 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR10</name>
+              <description>Reset bit 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR11</name>
+              <description>Reset bit 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR12</name>
+              <description>Reset bit 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR13</name>
+              <description>Reset bit 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR14</name>
+              <description>Reset bit 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR15</name>
+              <description>Reset bit 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR16</name>
+              <description>Reset bit 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR17</name>
+              <description>Reset bit 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR18</name>
+              <description>Reset bit 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR19</name>
+              <description>Reset bit 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR20</name>
+              <description>Reset bit 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR21</name>
+              <description>Reset bit 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR22</name>
+              <description>Reset bit 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>BR23</name>
+              <description>Reset bit 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LCKR</name>
+          <displayName>LCKR</displayName>
+          <description>Port configuration lock
+          register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LCK0</name>
+              <description>Port A Lock bit 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK1</name>
+              <description>Port A Lock bit 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK2</name>
+              <description>Port A Lock bit 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK3</name>
+              <description>Port A Lock bit 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK4</name>
+              <description>Port A Lock bit 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK5</name>
+              <description>Port A Lock bit 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK6</name>
+              <description>Port A Lock bit 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK7</name>
+              <description>Port A Lock bit 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK8</name>
+              <description>Port A Lock bit 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK9</name>
+              <description>Port A Lock bit 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK10</name>
+              <description>Port A Lock bit 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK11</name>
+              <description>Port A Lock bit 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK12</name>
+              <description>Port A Lock bit 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK13</name>
+              <description>Port A Lock bit 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK14</name>
+              <description>Port A Lock bit 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCK15</name>
+              <description>Port A Lock bit 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK16</name>
+              <description>Port A Lock bit 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK17</name>
+              <description>Port A Lock bit 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK18</name>
+              <description>Port A Lock bit 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK19</name>
+              <description>Port A Lock bit 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK20</name>
+              <description>Port A Lock bit 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK21</name>
+              <description>Port A Lock bit 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK22</name>
+              <description>Port A Lock bit 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LCK23</name>
+              <description>Port A Lock bit 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LCKK</name>
+              <description>Lock key</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGXR</name>
+          <displayName>CFGXR</displayName>
+          <description>Port configuration register extension
+          (GPIOn_CFGXR)</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x44444444</resetValue>
+          <fields>
+            <field>
+              <name>MODE16</name>
+              <description>Port n.16 mode bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF16</name>
+              <description>Port n.16 configuration
+              bits</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE17</name>
+              <description>Port n.17 mode bits</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF17</name>
+              <description>Port n.17 configuration
+              bits</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE18</name>
+              <description>Port n.18 mode bits</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF18</name>
+              <description>Port n.18 configuration
+              bits</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE19</name>
+              <description>Port n.19 mode bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF19</name>
+              <description>Port n.19 configuration
+              bits</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE20</name>
+              <description>Port n.20 mode bits</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF20</name>
+              <description>Port n.20 configuration
+              bits</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE21</name>
+              <description>Port n.21 mode bits</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF21</name>
+              <description>Port n.21 configuration
+              bits</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE22</name>
+              <description>Port n.22 mode bits</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF22</name>
+              <description>Port n.22 configuration
+              bits</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE23</name>
+              <description>Port n.23 mode bits</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CNF23</name>
+              <description>Port n.23 configuration
+              bits</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>BSXR</name>
+          <displayName>BSXR</displayName>
+          <description>Port bit set/reset register
+          (GPIOn_BSXR)</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BS16</name>
+              <description>Set bit 16</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS17</name>
+              <description>Set bit 17</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS18</name>
+              <description>Set bit 18</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS19</name>
+              <description>Set bit 19</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS20</name>
+              <description>Set bit 20</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS21</name>
+              <description>Set bit 21</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS22</name>
+              <description>Set bit 22</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BS23</name>
+              <description>Set bit 23</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR16</name>
+              <description>Reset bit 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR17</name>
+              <description>Reset bit 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR18</name>
+              <description>Reset bit 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR19</name>
+              <description>Reset bit 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR20</name>
+              <description>Reset bit 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR21</name>
+              <description>Reset bit 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR22</name>
+              <description>Reset bit 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BR23</name>
+              <description>Reset bit 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOB</name>
+      <baseAddress>0x40010C00</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="GPIOA">
+      <name>GPIOC</name>
+      <baseAddress>0x40011000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>AFIO</name>
+      <description>Alternate function I/O</description>
+      <groupName>AFIO</groupName>
+      <baseAddress>0x40010000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+
+        <register>
+          <name>PCFR1</name>
+          <displayName>PCFR1</displayName>
+          <description>AF remap and debug I/O configuration
+          register (AFIO_PCFR1)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SPI1RM</name>
+              <description>SPI1 remapping</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>I2C1RM</name>
+              <description>I2C1 remapping</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>USART1RM</name>
+              <description>USART1 remapping</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>USART2RM</name>
+              <description>USART2 remapping</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>USART3RM</name>
+              <description>USART3 remapping</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>USART4RM</name>
+              <description>USART4 remapping</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM1RM</name>
+              <description>TIM1 remapping</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM2RM</name>
+              <description>TIM2 remapping</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TIM3RM</name>
+              <description>TIM3 remapping</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+
+            <field>
+              <name>PLOC_RM</name>
+              <description>IO2W_RM remapping</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>SW_CFG</name>
+              <description>SW_CFG Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR1</name>
+          <displayName>EXTICR1</displayName>
+          <description>External interrupt configuration register 1
+          (AFIO_EXTICR1)</description>
+          <addressOffset>0x08</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI0</name>
+              <description>EXTI0 configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI1</name>
+              <description>EXTI1 configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI2</name>
+              <description>EXTI2 configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI3</name>
+              <description>EXTI3 configuration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI4</name>
+              <description>EXTI4 configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI5</name>
+              <description>EXTI5 configuration</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI6</name>
+              <description>EXTI6 configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI7</name>
+              <description>EXTI7 configuration</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            
+            <field>
+              <name>EXTI8</name>
+              <description>EXTI8 configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI9</name>
+              <description>EXTI9 configuration</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI10</name>
+              <description>EXTI10 configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI11</name>
+              <description>EXTI11 configuration</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI12</name>
+              <description>EXTI12 configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI13</name>
+              <description>EXTI13 configuration</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI14</name>
+              <description>EXTI14 configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI15</name>
+              <description>EXTI15 configuration</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTICR2</name>
+          <displayName>EXTICR2</displayName>
+          <description>External interrupt configuration register 2
+          (AFIO_EXTICR2)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EXTI16</name>
+              <description>EXTI16 configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI17</name>
+              <description>EXTI17 configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI18</name>
+              <description>EXTI18 configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI19</name>
+              <description>EXTI19 configuration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI20</name>
+              <description>EXTI20 configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI21</name>
+              <description>EXTI21 configuration</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI22</name>
+              <description>EXTI22 configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>EXTI23</name>
+              <description>EXTI23 configuration</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>CTLR</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>UDM_PUE</name>
+              <description>UDM_PUE configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>UDP_PUE</name>
+              <description>UDP_PUE configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USB_PHY_V33</name>
+              <description>USB_PHY_V33 configuration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USB_IOEN</name>
+              <description>USB_IOEN configuration</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USBPD_PHY_V33</name>
+              <description>USBPD_PHY_V33 configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>USBPD_IN_HVT</name>
+              <description>USBPD_IN_HVT configuration</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>UDP_BC_VSRC</name>
+              <description>UDP_BC_VSRC configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>UDM_BC_VSRC</name>
+              <description>UDM_BC_VSRC configuration</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>UDP_BC_CMPO</name>
+              <description>UDP_BC_CMPO configuration</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>UDM_BC_CMPO</name>
+              <description>UDM_BC_CMPO configuration</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>PA3_FILT_EN</name>
+              <description>PA3_FILT_EN configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PA4_FILT_EN</name>
+              <description>PA4_FILT_EN configuration</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PB5_FILT_EN</name>
+              <description>PB5_FILT_EN configuration</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PB6_FILT_EN</name>
+              <description>PB6_FILT_EN configuration</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register> 
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EXTI</name>
+      <description>EXTI</description>
+      <groupName>EXTI</groupName>
+      <baseAddress>0x40010400</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      
+      <interrupt>
+        <name>EXTI7_0</name>
+        <description>EXTI Line[7:0] interrupt</description>
+        <value>20</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI15_8</name>
+        <description>EXTI Line[15:8] interrupts</description>
+        <value>40</value>
+      </interrupt>
+      <interrupt>
+        <name>EXTI25_16</name>
+        <description>EXTI Line[25:16] interrupts</description>
+        <value>41</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENR</name>
+          <displayName>INTENR</displayName>
+          <description>Interrupt mask register
+          (EXTI_INTENR)</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MR0</name>
+              <description>Interrupt Mask on line 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR1</name>
+              <description>Interrupt Mask on line 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR2</name>
+              <description>Interrupt Mask on line 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR3</name>
+              <description>Interrupt Mask on line 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR4</name>
+              <description>Interrupt Mask on line 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR5</name>
+              <description>Interrupt Mask on line 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR6</name>
+              <description>Interrupt Mask on line 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR7</name>
+              <description>Interrupt Mask on line 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR8</name>
+              <description>Interrupt Mask on line 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR9</name>
+              <description>Interrupt Mask on line 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR10</name>
+              <description>Interrupt Mask on line 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR11</name>
+              <description>Interrupt Mask on line 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR12</name>
+              <description>Interrupt Mask on line 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR13</name>
+              <description>Interrupt Mask on line 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR14</name>
+              <description>Interrupt Mask on line 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR15</name>
+              <description>Interrupt Mask on line 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR16</name>
+              <description>Interrupt Mask on line 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR17</name>
+              <description>Interrupt Mask on line 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR18</name>
+              <description>Interrupt Mask on line 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR19</name>
+              <description>Interrupt Mask on line 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR20</name>
+              <description>Interrupt Mask on line 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR21</name>
+              <description>Interrupt Mask on line 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR22</name>
+              <description>Interrupt Mask on line 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR23</name>
+              <description>Interrupt Mask on line 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR24</name>
+              <description>Interrupt Mask on line 24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR25</name>
+              <description>Interrupt Mask on line 25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR26</name>
+              <description>Interrupt Mask on line 26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR27</name>
+              <description>Interrupt Mask on line 27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR28</name>
+              <description>Interrupt Mask on line 28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR29</name>
+              <description>Interrupt Mask on line 29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVENR</name>
+          <displayName>EVENR</displayName>
+          <description>Event mask register (EXTI_EVENR)</description>
+          <addressOffset>0x04</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MR0</name>
+              <description>Event Mask on line 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR1</name>
+              <description>Event Mask on line 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR2</name>
+              <description>Event Mask on line 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR3</name>
+              <description>Event Mask on line 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR4</name>
+              <description>Event Mask on line 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR5</name>
+              <description>Event Mask on line 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR6</name>
+              <description>Event Mask on line 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR7</name>
+              <description>Event Mask on line 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR8</name>
+              <description>Event Mask on line 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR9</name>
+              <description>Event Mask on line 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR10</name>
+              <description>Event Mask on line 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR11</name>
+              <description>Event Mask on line 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR12</name>
+              <description>Event Mask on line 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR13</name>
+              <description>Event Mask on line 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR14</name>
+              <description>Event Mask on line 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR15</name>
+              <description>Event Mask on line 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR16</name>
+              <description>Event Mask on line 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR17</name>
+              <description>Event Mask on line 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR18</name>
+              <description>Event Mask on line 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MR19</name>
+              <description>Event Mask on line 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR20</name>
+              <description>Event Mask on line 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR21</name>
+              <description>Event Mask on line 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR22</name>
+              <description>Event Mask on line 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR23</name>
+              <description>Event Mask on line 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR24</name>
+              <description>Event Mask on line 24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR25</name>
+              <description>Event Mask on line 25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR26</name>
+              <description>Event Mask on line 26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR27</name>
+              <description>Event Mask on line 27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR28</name>
+              <description>Event Mask on line 28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MR29</name>
+              <description>Event Mask on line 29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RTENR</name>
+          <displayName>RTENR</displayName>
+          <description>Rising Trigger selection register
+          (EXTI_RTENR)</description>
+          <addressOffset>0x08</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TR0</name>
+              <description>Rising trigger event configuration of
+              line 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR1</name>
+              <description>Rising trigger event configuration of
+              line 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR2</name>
+              <description>Rising trigger event configuration of
+              line 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR3</name>
+              <description>Rising trigger event configuration of
+              line 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR4</name>
+              <description>Rising trigger event configuration of
+              line 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR5</name>
+              <description>Rising trigger event configuration of
+              line 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR6</name>
+              <description>Rising trigger event configuration of
+              line 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR7</name>
+              <description>Rising trigger event configuration of
+              line 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR8</name>
+              <description>Rising trigger event configuration of
+              line 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR9</name>
+              <description>Rising trigger event configuration of
+              line 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR10</name>
+              <description>Rising trigger event configuration of
+              line 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR11</name>
+              <description>Rising trigger event configuration of
+              line 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR12</name>
+              <description>Rising trigger event configuration of
+              line 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR13</name>
+              <description>Rising trigger event configuration of
+              line 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR14</name>
+              <description>Rising trigger event configuration of
+              line 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR15</name>
+              <description>Rising trigger event configuration of
+              line 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR16</name>
+              <description>Rising trigger event configuration of
+              line 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR17</name>
+              <description>Rising trigger event configuration of
+              line 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR18</name>
+              <description>Rising trigger event configuration of
+              line 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR19</name>
+              <description>Rising trigger event configuration of
+              line 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR20</name>
+              <description>Rising trigger event configuration of
+              line 10</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR21</name>
+              <description>Rising trigger event configuration of
+              line 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR22</name>
+              <description>Rising trigger event configuration of
+              line 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR23</name>
+              <description>Rising trigger event configuration of
+              line 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR24</name>
+              <description>Rising trigger event configuration of
+              line 24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR25</name>
+              <description>Rising trigger event configuration of
+              line 25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR26</name>
+              <description>Rising trigger event configuration of
+              line 26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR27</name>
+              <description>Rising trigger event configuration of
+              line 27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR28</name>
+              <description>Rising trigger event configuration of
+              line 28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR29</name>
+              <description>Rising trigger event configuration of
+              line 29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FTENR</name>
+          <displayName>FTENR</displayName>
+          <description>Falling Trigger selection register
+          (EXTI_FTENR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>TR0</name>
+              <description>Falling trigger event configuration of
+              line 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR1</name>
+              <description>Falling trigger event configuration of
+              line 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR2</name>
+              <description>Falling trigger event configuration of
+              line 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR3</name>
+              <description>Falling trigger event configuration of
+              line 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR4</name>
+              <description>Falling trigger event configuration of
+              line 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR5</name>
+              <description>Falling trigger event configuration of
+              line 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR6</name>
+              <description>Falling trigger event configuration of
+              line 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR7</name>
+              <description>Falling trigger event configuration of
+              line 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR8</name>
+              <description>Falling trigger event configuration of
+              line 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR9</name>
+              <description>Falling trigger event configuration of
+              line 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR10</name>
+              <description>Falling trigger event configuration of
+              line 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR11</name>
+              <description>Falling trigger event configuration of
+              line 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR12</name>
+              <description>Falling trigger event configuration of
+              line 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR13</name>
+              <description>Falling trigger event configuration of
+              line 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR14</name>
+              <description>Falling trigger event configuration of
+              line 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR15</name>
+              <description>Falling trigger event configuration of
+              line 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR16</name>
+              <description>Falling trigger event configuration of
+              line 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR17</name>
+              <description>Falling trigger event configuration of
+              line 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR18</name>
+              <description>Falling trigger event configuration of
+              line 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TR19</name>
+              <description>Falling trigger event configuration of
+              line 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR20</name>
+              <description>Falling trigger event configuration of
+              line 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR21</name>
+              <description>Falling trigger event configuration of
+              line 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR22</name>
+              <description>Falling trigger event configuration of
+              line 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR23</name>
+              <description>Falling trigger event configuration of
+              line 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR24</name>
+              <description>Falling trigger event configuration of
+              line 24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR25</name>
+              <description>Falling trigger event configuration of
+              line 25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR26</name>
+              <description>Falling trigger event configuration of
+              line 26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR27</name>
+              <description>Falling trigger event configuration of
+              line 27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR28</name>
+              <description>Falling trigger event configuration of
+              line 28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TR29</name>
+              <description>Falling trigger event configuration of
+              line 29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWIEVR</name>
+          <displayName>SWIEVR</displayName>
+          <description>Software interrupt event register
+          (EXTI_SWIEVR)</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SWIER0</name>
+              <description>Software Interrupt on line
+              0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER1</name>
+              <description>Software Interrupt on line
+              1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER2</name>
+              <description>Software Interrupt on line
+              2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER3</name>
+              <description>Software Interrupt on line
+              3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER4</name>
+              <description>Software Interrupt on line
+              4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER5</name>
+              <description>Software Interrupt on line
+              5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER6</name>
+              <description>Software Interrupt on line
+              6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER7</name>
+              <description>Software Interrupt on line
+              7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER8</name>
+              <description>Software Interrupt on line
+              8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER9</name>
+              <description>Software Interrupt on line
+              9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER10</name>
+              <description>Software Interrupt on line
+              10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER11</name>
+              <description>Software Interrupt on line
+              11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER12</name>
+              <description>Software Interrupt on line
+              12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER13</name>
+              <description>Software Interrupt on line
+              13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER14</name>
+              <description>Software Interrupt on line
+              14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER15</name>
+              <description>Software Interrupt on line
+              15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER16</name>
+              <description>Software Interrupt on line
+              16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER17</name>
+              <description>Software Interrupt on line
+              17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER18</name>
+              <description>Software Interrupt on line
+              18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWIER19</name>
+              <description>Software Interrupt on line
+              19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER20</name>
+              <description>Software Interrupt on line
+              20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER21</name>
+              <description>Software Interrupt on line
+              21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER22</name>
+              <description>Software Interrupt on line
+              22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER23</name>
+              <description>Software Interrupt on line
+              23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER24</name>
+              <description>Software Interrupt on line
+              24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER25</name>
+              <description>Software Interrupt on line
+              25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER26</name>
+              <description>Software Interrupt on line
+              26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER27</name>
+              <description>Software Interrupt on line
+              27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER28</name>
+              <description>Software Interrupt on line
+              28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>SWIER29</name>
+              <description>Software Interrupt on line
+              29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFR</name>
+          <displayName>INTFR</displayName>
+          <description>Interrupt flag register (EXTI_INTFR)</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IF0</name>
+              <description>Interrupt flag  bit 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+            <field>
+              <name>IF1</name>
+              <description>Interrupt flag  bit 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF2</name>
+              <description>Interrupt flag  bit 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF3</name>
+              <description>Interrupt flag  bit 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF4</name>
+              <description>Interrupt flag  bit 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF5</name>
+              <description>Interrupt flag  bit 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF6</name>
+              <description>Interrupt flag  bit 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF7</name>
+              <description>Interrupt flag  bit 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF8</name>
+              <description>Interrupt flag  bit 8</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF9</name>
+              <description>Interrupt flag  bit 9</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF10</name>
+              <description>Interrupt flag  bit 10</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF11</name>
+              <description>Interrupt flag  bit 11</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF12</name>
+              <description>Interrupt flag  bit 12</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF13</name>
+              <description>Interrupt flag  bit 13</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF14</name>
+              <description>Interrupt flag  bit 14</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF15</name>
+              <description>Interrupt flag  bit 15</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF16</name>
+              <description>Interrupt flag  bit 16</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF17</name>
+              <description>Interrupt flag  bit 17</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF18</name>
+              <description>Interrupt flag  bit 18</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF19</name>
+              <description>Interrupt flag  bit 19</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF20</name>
+              <description>Interrupt flag  bit 20</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF21</name>
+              <description>Interrupt flag  bit 21</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF22</name>
+              <description>Interrupt flag  bit 22</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF23</name>
+              <description>Interrupt flag  bit 23</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF24</name>
+              <description>Interrupt flag  bit 24</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF25</name>
+              <description>Interrupt flag  bit 25</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF26</name>
+              <description>Interrupt flag  bit 26</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF27</name>
+              <description>Interrupt flag  bit 27</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF28</name>
+              <description>Interrupt flag  bit 28</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>IF29</name>
+              <description>Interrupt flag  bit 29</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMA</name>
+      <description>DMA controller</description>
+      <groupName>DMA</groupName>
+      <baseAddress>0x40020000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMA_Channel1</name>
+        <description>DMA Channel1 global interrupt</description>
+        <value>22</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel2</name>
+        <description>DMA Channel2 global interrupt</description>
+        <value>23</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel3</name>
+        <description>DMA Channel3 global interrupt</description>
+        <value>24</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel4</name>
+        <description>DMA Channel4 global interrupt</description>
+        <value>25</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel5</name>
+        <description>DMA Channel5 global interrupt</description>
+        <value>26</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel6</name>
+        <description>DMA Channel6 global interrupt</description>
+        <value>27</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel7</name>
+        <description>DMA Channel7 global interrupt</description>
+        <value>28</value>
+      </interrupt>
+      <interrupt>
+        <name>DMA_Channel8</name>
+        <description>DMA Channel8 global interrupt</description>
+        <value>44</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTFR</name>
+          <displayName>INTFR</displayName>
+          <description>DMA interrupt status register
+          (DMA_INTFR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GIF1</name>
+              <description>Channel 1 Global interrupt
+              flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF1</name>
+              <description>Channel 1 Transfer Complete
+              flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF1</name>
+              <description>Channel 1 Half Transfer Complete
+              flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF1</name>
+              <description>Channel 1 Transfer Error
+              flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF2</name>
+              <description>Channel 2 Global interrupt
+              flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF2</name>
+              <description>Channel 2 Transfer Complete
+              flag</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF2</name>
+              <description>Channel 2 Half Transfer Complete
+              flag</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF2</name>
+              <description>Channel 2 Transfer Error
+              flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF3</name>
+              <description>Channel 3 Global interrupt
+              flag</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF3</name>
+              <description>Channel 3 Transfer Complete
+              flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF3</name>
+              <description>Channel 3 Half Transfer Complete
+              flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF3</name>
+              <description>Channel 3 Transfer Error
+              flag</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF4</name>
+              <description>Channel 4 Global interrupt
+              flag</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF4</name>
+              <description>Channel 4 Transfer Complete
+              flag</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF4</name>
+              <description>Channel 4 Half Transfer Complete
+              flag</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF4</name>
+              <description>Channel 4 Transfer Error
+              flag</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF5</name>
+              <description>Channel 5 Global interrupt
+              flag</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF5</name>
+              <description>Channel 5 Transfer Complete
+              flag</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF5</name>
+              <description>Channel 5 Half Transfer Complete
+              flag</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF5</name>
+              <description>Channel 5 Transfer Error
+              flag</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF6</name>
+              <description>Channel 6 Global interrupt
+              flag</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF6</name>
+              <description>Channel 6 Transfer Complete
+              flag</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF6</name>
+              <description>Channel 6 Half Transfer Complete
+              flag</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF6</name>
+              <description>Channel 6 Transfer Error
+              flag</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF7</name>
+              <description>Channel 7 Global interrupt
+              flag</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF7</name>
+              <description>Channel 7 Transfer Complete
+              flag</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF7</name>
+              <description>Channel 7 Half Transfer Complete
+              flag</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF7</name>
+              <description>Channel 7 Transfer Error
+              flag</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>GIF8</name>
+              <description>Channel 8 Global interrupt
+              flag</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TCIF8</name>
+              <description>Channel 8 Transfer Complete
+              flag</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>HTIF8</name>
+              <description>Channel 8 Half Transfer Complete
+              flag</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>TEIF8</name>
+              <description>Channel 8 Transfer Error
+              flag</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFCR</name>
+          <displayName>INTFCR</displayName>
+          <description>DMA interrupt flag clear register
+          (DMA_INTFCR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CGIF1</name>
+              <description>Channel 1 Global interrupt
+              clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF1</name>
+              <description>Channel 1 Transfer Complete
+              clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF1</name>
+              <description>Channel 1 Half Transfer
+              clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF1</name>
+              <description>Channel 1 Transfer Error
+              clear</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF2</name>
+              <description>Channel 2 Global interrupt
+              clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF2</name>
+              <description>Channel 2 Transfer Complete
+              clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF2</name>
+              <description>Channel 2 Half Transfer
+              clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF2</name>
+              <description>Channel 2 Transfer Error
+              clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF3</name>
+              <description>Channel 3 Global interrupt
+              clear</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF3</name>
+              <description>Channel 3 Transfer Complete
+              clear</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF3</name>
+              <description>Channel 3 Half Transfer
+              clear</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF3</name>
+              <description>Channel 3 Transfer Error
+              clear</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF4</name>
+              <description>Channel 4 Global interrupt
+              clear</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF4</name>
+              <description>Channel 4 Transfer Complete
+              clear</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF4</name>
+              <description>Channel 4 Half Transfer
+              clear</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF4</name>
+              <description>Channel 4 Transfer Error
+              clear</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF5</name>
+              <description>Channel 5 Global interrupt
+              clear</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF5</name>
+              <description>Channel 5 Transfer Complete
+              clear</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF5</name>
+              <description>Channel 5 Half Transfer
+              clear</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF5</name>
+              <description>Channel 5 Transfer Error
+              clear</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF6</name>
+              <description>Channel 6 Global interrupt
+              clear</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF6</name>
+              <description>Channel 6 Transfer Complete
+              clear</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF6</name>
+              <description>Channel 6 Half Transfer
+              clear</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF6</name>
+              <description>Channel 6 Transfer Error
+              clear</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF7</name>
+              <description>Channel 7 Global interrupt
+              clear</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTCIF7</name>
+              <description>Channel 7 Transfer Complete
+              clear</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CHTIF7</name>
+              <description>Channel 7 Half Transfer
+              clear</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CTEIF7</name>
+              <description>Channel 7 Transfer Error
+              clear</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CGIF8</name>
+              <description>Channel 8 Global interrupt
+              clear</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CTCIF8</name>
+              <description>Channel 8 Transfer Complete
+              clear</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CHTIF8</name>
+              <description>Channel 8 Half Transfer
+              clear</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CTEIF8</name>
+              <description>Channel 8 Transfer Error
+              clear</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>DMA channel 1 configuration register
+          (DMA_CFGR1)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR1</name>
+          <displayName>CNTR1</displayName>
+          <description>DMA channel 1 number of data
+          register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR1</name>
+          <displayName>PADDR1</displayName>
+          <description>DMA channel 1 peripheral address
+          register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR1</name>
+          <displayName>MADDR1</displayName>
+          <description>DMA channel 1 memory address
+          register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>DMA channel 2 configuration register
+          (DMA_CFGR2)</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR2</name>
+          <displayName>CNTR2</displayName>
+          <description>DMA channel 2 number of data
+          register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR2</name>
+          <displayName>PADDR2</displayName>
+          <description>DMA channel 2 peripheral address
+          register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR2</name>
+          <displayName>MADDR2</displayName>
+          <description>DMA channel 2 memory address
+          register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR3</name>
+          <displayName>CFGR3</displayName>
+          <description>DMA channel 3 configuration register
+          (DMA_CFGR3)</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR3</name>
+          <displayName>CNTR3</displayName>
+          <description>DMA channel 3 number of data
+          register</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR3</name>
+          <displayName>PADDR3</displayName>
+          <description>DMA channel 3 peripheral address
+          register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR3</name>
+          <displayName>MADDR3</displayName>
+          <description>DMA channel 3 memory address
+          register</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR4</name>
+          <displayName>CFGR4</displayName>
+          <description>DMA channel 4 configuration register
+          (DMA_CFGR4)</description>
+          <addressOffset>0x44</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR4</name>
+          <displayName>CNTR4</displayName>
+          <description>DMA channel 4 number of data
+          register</description>
+          <addressOffset>0x48</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR4</name>
+          <displayName>PADDR4</displayName>
+          <description>DMA channel 4 peripheral address
+          register</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR4</name>
+          <displayName>MADDR4</displayName>
+          <description>DMA channel 4 memory address
+          register</description>
+          <addressOffset>0x50</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR5</name>
+          <displayName>CFGR5</displayName>
+          <description>DMA channel 5 configuration register
+          (DMA_CFGR1)</description>
+          <addressOffset>0x58</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR5</name>
+          <displayName>CNTR5</displayName>
+          <description>DMA channel 5 number of data
+          register</description>
+          <addressOffset>0x5C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR5</name>
+          <displayName>PADDR5</displayName>
+          <description>DMA channel 5 peripheral address
+          register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR5</name>
+          <displayName>MADDR5</displayName>
+          <description>DMA channel 5 memory address
+          register</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR6</name>
+          <displayName>CFGR6</displayName>
+          <description>DMA channel 6 configuration register
+          (DMA_CFGR1)</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR6</name>
+          <displayName>CNTR6</displayName>
+          <description>DMA channel 6 number of data
+          register</description>
+          <addressOffset>0x70</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR6</name>
+          <displayName>PADDR6</displayName>
+          <description>DMA channel 6 peripheral address
+          register</description>
+          <addressOffset>0x74</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR6</name>
+          <displayName>MADDR6</displayName>
+          <description>DMA channel 6 memory address
+          register</description>
+          <addressOffset>0x78</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR7</name>
+          <displayName>CFGR7</displayName>
+          <description>DMA channel 7 configuration register
+          (DMA_CFGR1)</description>
+          <addressOffset>0x80</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR7</name>
+          <displayName>CNTR7</displayName>
+          <description>DMA channel 7 number of data
+          register</description>
+          <addressOffset>0x84</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR7</name>
+          <displayName>PADDR7</displayName>
+          <description>DMA channel 7 peripheral address
+          register</description>
+          <addressOffset>0x88</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR7</name>
+          <displayName>MADDR7</displayName>
+          <description>DMA channel 7 memory address
+          register</description>
+          <addressOffset>0x8C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR8</name>
+          <displayName>CFGR8</displayName>
+          <description>DMA channel 8 configuration register
+          (DMA_CFGR1)</description>
+          <addressOffset>0x94</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EN</name>
+              <description>Channel enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transfer complete interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>HTIE</name>
+              <description>Half Transfer interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TEIE</name>
+              <description>Transfer error interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Data transfer direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CIRC</name>
+              <description>Circular mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PINC</name>
+              <description>Peripheral increment mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MINC</name>
+              <description>Memory increment mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PSIZE</name>
+              <description>Peripheral size</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MSIZE</name>
+              <description>Memory size</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>PL</name>
+              <description>Channel Priority level</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MEM2MEM</name>
+              <description>Memory to memory mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNTR8</name>
+          <displayName>CNTR8</displayName>
+          <description>DMA channel 8 number of data
+          register</description>
+          <addressOffset>0x98</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NDT</name>
+              <description>Number of data to transfer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADDR8</name>
+          <displayName>PADDR8</displayName>
+          <description>DMA channel 8 peripheral address
+          register</description>
+          <addressOffset>0x9C</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PA</name>
+              <description>Peripheral address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MADDR8</name>
+          <displayName>MADDR8</displayName>
+          <description>DMA channel 8 memory address
+          register</description>
+          <addressOffset>0xA0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MA</name>
+              <description>Memory address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>IWDG</name>
+      <description>Independent watchdog</description>
+      <groupName>IWDG</groupName>
+      <baseAddress>0x40003000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>Key register (IWDG_CTLR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>KEY</name>
+              <description>Key value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSCR</name>
+          <displayName>PSCR</displayName>
+          <description>Prescaler register (IWDG_PSCR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PR</name>
+              <description>Prescaler divider</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RLDR</name>
+          <displayName>RLDR</displayName>
+          <description>Reload register (IWDG_RLDR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0FFF</resetValue>
+          <fields>
+            <field>
+              <name>RL</name>
+              <description>Watchdog counter reload
+              value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>Status register (IWDG_SR)</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PVU</name>
+              <description>Watchdog prescaler value
+              update</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RVU</name>
+              <description>Watchdog counter reload value
+              update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WWDG</name>
+      <description>Window watchdog</description>
+      <groupName>WWDG</groupName>
+      <baseAddress>0x40002C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WWDG</name>
+        <description>Window Watchdog interrupt</description>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>Control register (WWDG_CR)</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x007F</resetValue>
+          <fields>
+            <field>
+              <name>T</name>
+              <description>7-bit counter (MSB to LSB)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>WDGA</name>
+              <description>Activation bit</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Configuration register
+          (WWDG_CFR)</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x007F</resetValue>
+          <fields>
+            <field>
+              <name>W</name>
+              <description>7-bit window value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>WDGTB</name>
+              <description>Timer Base</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>EWI</name>
+              <description>Early Wakeup Interrupt</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/set</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>Status register (WWDG_SR)</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EWIF</name>
+              <description>Early Wakeup Interrupt Flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TIM1</name>
+      <description>Advanced timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40012C00</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM1_BRK</name>
+        <description>TIM1 Break
+        interrupt</description>
+        <value>34</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_UP_</name>
+        <description>TIM1 Update 
+        interrupt</description>
+        <value>35</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_TRG_COM</name>
+        <description>TIM1 Trigger and Commutation interrupts</description>
+        <value>36</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM1_CC</name>
+        <description>TIM1 Capture Compare interrupt</description>
+        <value>37</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+		  <field>
+              <name>CEN</name>
+              <description>Counter enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>UDIS</name>
+              <description>Update disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>URS</name>
+              <description>Update request source</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OPM</name>
+              <description>One-pulse mode</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>DIR</name>
+              <description>Direction</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CMS</name>
+              <description>Center-aligned mode
+              selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ARPE</name>
+              <description>Auto-reload preload enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>Clock division</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CAPOV</name>
+              <description>CAPOV</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CAPLVL</name>
+              <description>CAPLVL</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+		  <field>
+              <name>CCPC</name>
+              <description>Capture/compare preloaded
+              control</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CCUS</name>
+              <description>Capture/compare control update
+              selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CCDS</name>
+              <description>Capture/compare DMA
+              selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MMS</name>
+              <description>Master mode selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TI1S</name>
+              <description>TI1 selection</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS1</name>
+              <description>Output Idle state 1</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS1N</name>
+              <description>Output Idle state 1</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS2</name>
+              <description>Output Idle state 2</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS2N</name>
+              <description>Output Idle state 2</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS3</name>
+              <description>Output Idle state 3</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OIS3N</name>
+              <description>Output Idle state 3</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>OIS4</name>
+              <description>Output Idle state 4</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>           
+          </fields>
+        </register>
+        <register>
+          <name>SMCFGR</name>
+          <displayName>SMCFGR</displayName>
+          <description>slave mode control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>SMS</name>
+              <description>Slave mode selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TS</name>
+              <description>Trigger selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>MSM</name>
+              <description>Master/Slave mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ETF</name>
+              <description>External trigger filter</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ETPS</name>
+              <description>External trigger prescaler</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ECE</name>
+              <description>External clock enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ETP</name>
+              <description>External trigger polarity</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>     
+          </fields>
+        </register>
+        <register>
+          <name>DMAINTENR</name>
+          <displayName>DMAINTENR</displayName>
+          <description>DMA/Interrupt enable register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>UIE</name>
+              <description>Update interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1IE</name>
+              <description>Capture/Compare 1 interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2IE</name>
+              <description>Capture/Compare 2 interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3IE</name>
+              <description>Capture/Compare 3 interrupt
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC4IE</name>
+              <description>Capture/Compare 4 interrupt
+              enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>COMIE</name>
+              <description>COM interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TIE</name>
+              <description>Trigger interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>BIE</name>
+              <description>Break interrupt enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>UDE</name>
+              <description>Update DMA request enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1DE</name>
+              <description>Capture/Compare 1 DMA request
+              enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2DE</name>
+              <description>Capture/Compare 2 DMA request
+              enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3DE</name>
+              <description>Capture/Compare 3 DMA request
+              enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC4DE</name>
+              <description>Capture/Compare 4 DMA request
+              enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>COMDE</name>
+              <description>COM DMA request enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TDE</name>
+              <description>Trigger DMA request enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>          
+          </fields>
+        </register>
+        <register>
+          <name>INTFR</name>
+          <displayName>INTFR</displayName>
+          <description>status register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>UIF</name>
+              <description>Update interrupt flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC1IF</name>
+              <description>Capture/compare 1 interrupt
+              flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC2IF</name>
+              <description>Capture/Compare 2 interrupt
+              flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC3IF</name>
+              <description>Capture/Compare 3 interrupt
+              flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC4IF</name>
+              <description>Capture/Compare 4 interrupt
+              flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>COMIF</name>
+              <description>COM interrupt flag</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>TIF</name>
+              <description>Trigger interrupt flag</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>BIF</name>
+              <description>Break interrupt flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC1OF</name>
+              <description>Capture/Compare 1 overcapture
+              flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC2OF</name>
+              <description>Capture/compare 2 overcapture
+              flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+			<field>
+              <name>CC3OF</name>
+              <description>Capture/Compare 3 overcapture
+              flag</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>
+            <field>
+              <name>CC4OF</name>
+              <description>Capture/Compare 4 overcapture
+              flag</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read/clear</access>
+            </field>     
+          </fields>
+        </register>
+        <register>
+          <name>SWEVGR</name>
+          <displayName>SWEVGR</displayName>
+          <description>event generation register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>UG</name>
+              <description>Update generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC1G</name>
+              <description>Capture/compare 1
+              generation</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC2G</name>
+              <description>Capture/compare 2
+              generation</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC3G</name>
+              <description>Capture/compare 3
+              generation</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC4G</name>
+              <description>Capture/compare 4
+              generation</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>COMG</name>
+              <description>Capture/Compare control update
+              generation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>TG</name>
+              <description>Trigger generation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>BG</name>
+              <description>Break generation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR1_Output</name>
+          <displayName>CHCTLR1_Output</displayName>
+          <description>capture/compare mode register (output
+          mode)</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC1S</name>
+              <description>Capture/Compare 1
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1FE</name>
+              <description>Output Compare 1 fast
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1PE</name>
+              <description>Output Compare 1 preload
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1M</name>
+              <description>Output Compare 1 mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1CE</name>
+              <description>Output Compare 1 clear
+              enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2S</name>
+              <description>Capture/Compare 2
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2FE</name>
+              <description>Output Compare 2 fast
+              enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2PE</name>
+              <description>Output Compare 2 preload
+              enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2M</name>
+              <description>Output Compare 2 mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>Output Compare 2 clear
+              enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>       
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR1_Input</name>
+          <displayName>CHCTLR1_Input</displayName>
+          <description>capture/compare mode register 1 (input
+          mode)</description>
+          <alternateRegister>CHCTLR1_Output</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC1S</name>
+              <description>Capture/Compare 1
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC1PSC</name>
+              <description>Input capture 1 prescaler</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC1F</name>
+              <description>Input capture 1 filter</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2S</name>
+              <description>Capture/Compare 2
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC2PCS</name>
+              <description>Input capture 2 prescaler</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>Input capture 2 filter</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field> 
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR2_Output</name>
+          <displayName>CHCTLR2_Output</displayName>
+          <description>capture/compare mode register (output
+          mode)</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC3S</name>
+              <description>Capture/Compare 3
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC3FE</name>
+              <description>Output compare 3 fast
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC3PE</name>
+              <description>Output compare 3 preload
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC3M</name>
+              <description>Output compare 3 mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC3CE</name>
+              <description>Output compare 3 clear
+              enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC4S</name>
+              <description>Capture/Compare 4
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC4FE</name>
+              <description>Output compare 4 fast
+              enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC4PE</name>
+              <description>Output compare 4 preload
+              enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC4M</name>
+              <description>Output compare 4 mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>OC4CE</name>
+              <description>Output compare 4 clear
+              enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>         
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR2_Input</name>
+          <displayName>CHCTLR2_Input</displayName>
+          <description>capture/compare mode register 2 (input
+          mode)</description>
+          <alternateRegister>CHCTLR2_Output</alternateRegister>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC3S</name>
+              <description>Capture/compare 3
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC3PSC</name>
+              <description>Input capture 3 prescaler</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC3F</name>
+              <description>Input capture 3 filter</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC4S</name>
+              <description>Capture/Compare 4
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC4PSC</name>
+              <description>Input capture 4 prescaler</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IC4F</name>
+              <description>Input capture 4 filter</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>         
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <displayName>CCER</displayName>
+          <description>capture/compare enable
+          register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC1E</name>
+              <description>Capture/Compare 1 output
+              enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1P</name>
+              <description>Capture/Compare 1 output
+              Polarity</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1NE</name>
+              <description>Capture/Compare 1 complementary output
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1NP</name>
+              <description>Capture/Compare 1 output
+              Polarity</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2E</name>
+              <description>Capture/Compare 2 output
+              enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2P</name>
+              <description>Capture/Compare 2 output
+              Polarity</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2NE</name>
+              <description>Capture/Compare 2 complementary output
+              enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2NP</name>
+              <description>Capture/Compare 2 output
+              Polarity</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3E</name>
+              <description>Capture/Compare 3 output
+              enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3P</name>
+              <description>Capture/Compare 3 output
+              Polarity</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3NE</name>
+              <description>Capture/Compare 3 complementary output
+              enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC3NP</name>
+              <description>Capture/Compare 3 output
+              Polarity</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC4E</name>
+              <description>Capture/Compare 4 output
+              enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CC4P</name>
+              <description>Capture/Compare 3 output
+              Polarity</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>counter</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <displayName>PSC</displayName>
+          <description>prescaler</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>Prescaler value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ATRLR</name>
+          <displayName>ATRLR</displayName>
+          <description>auto-reload register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ATRLR</name>
+              <description>Auto-reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RPTCR</name>
+          <displayName>RPTCR</displayName>
+          <description>repetition counter register</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>RPTCR</name>
+              <description>Repetition counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH1CVR</name>
+          <displayName>CH1CVR</displayName>
+          <description>capture/compare register 1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH1CVR</name>
+              <description>Capture/Compare 1 value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH2CVR</name>
+          <displayName>CH2CVR</displayName>
+          <description>capture/compare register 2</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH2CVR</name>
+              <description>Capture/Compare 2 value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH3CVR</name>
+          <displayName>CH3CVR</displayName>
+          <description>capture/compare register 3</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH3CVR</name>
+              <description>Capture/Compare value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH4CVR</name>
+          <displayName>CH4CVR</displayName>
+          <description>capture/compare register 4</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH4CVR</name>
+              <description>Capture/Compare value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BDTR</name>
+          <displayName>BDTR</displayName>
+          <description>break and dead-time register</description>
+          <addressOffset>0x44</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>DTG</name>
+              <description>Dead-time generator setup</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>LOCK</name>
+              <description>Lock configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OSSI</name>
+              <description>Off-state selection for Idle
+              mode</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OSSR</name>
+              <description>Off-state selection for Run
+              mode</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>BKE</name>
+              <description>Break enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>BKP</name>
+              <description>Break polarity</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>AOE</name>
+              <description>Automatic output enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>MOE</name>
+              <description>Main output enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMACFGR</name>
+          <displayName>DMACFGR</displayName>
+          <description>DMA control register</description>
+          <addressOffset>0x48</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>DBA</name>
+              <description>DMA base address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>DBL</name>
+              <description>DMA burst length</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMAADR</name>
+          <displayName>DMAADR</displayName>
+          <description>DMA address for full transfer</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DMAADR</name>
+              <description>DMA register for burst
+              accesses</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>SPEC</name>
+          <displayName>SPEC</displayName>
+          <description>SPEC</description>
+          <addressOffset>0x50</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PWM_EN</name>
+              <description>PWM_EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC1</name>
+              <description>PWM_OC1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC5</name>
+              <description>PWM_OC5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC3</name>
+              <description>PWM_OC3</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC4</name>
+              <description>PWM_OC4</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TOGGLE</name>
+              <description>TOGGLE</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TIM1">
+      <name>TIM2</name>
+      <baseAddress>0x40000000</baseAddress>
+      <interrupt>
+        <name>TIM2_BRK</name>
+        <description>TIM2 Break
+        interrupt</description>
+        <value>53</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM2_UP_</name>
+        <description>TIM2 Update 
+        interrupt</description>
+        <value>38</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM2_TRG_COM</name>
+        <description>TIM2 Trigger and Commutation interrupts</description>
+        <value>52</value>
+      </interrupt>
+      <interrupt>
+        <name>TIM2_CC</name>
+        <description>TIM2 Capture Compare interrupt</description>
+        <value>51</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TIM3</name>
+      <description>General purpose timer</description>
+      <groupName>TIM</groupName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TIM3</name>
+        <description>TIM3 global interrupt</description>
+        <value>54</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CEN</name>
+              <description>Counter enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>UDIS</name>
+              <description>Update disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>URS</name>
+              <description>Update request source</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OPM</name>
+              <description>One-pulse mode</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ARPE</name>
+              <description>Auto-reload preload enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CKD</name>
+              <description>Clock division</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CAPOV</name>
+              <description>CAPOV</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CAPLVL</name>
+              <description>CAPLVL</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SMCFGR</name>
+          <displayName>SMCFGR</displayName>
+          <description>slave mode control register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>SMS</name>
+              <description>Slave mode selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TS</name>
+              <description>Trigger selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field> 
+          </fields>
+        </register>
+        <register>
+          <name>DMAINTENR</name>
+          <displayName>DMAINTENR</displayName>
+          <description>DMA/Interrupt enable register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>UIE</name>
+              <description>Update interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1IE</name>
+              <description>Capture/Compare 1 interrupt
+              enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2IE</name>
+              <description>Capture/Compare 2 interrupt
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>TIE</name>
+              <description>Trigger interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFR</name>
+          <displayName>INTFR</displayName>
+          <description>status register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>UIF</name>
+              <description>Update interrupt flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC1IF</name>
+              <description>Capture/compare 1 interrupt
+              flag</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC2IF</name>
+              <description>Capture/Compare 2 interrupt
+              flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>TIF</name>
+              <description>Trigger interrupt flag</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC1OF</name>
+              <description>Capture/Compare 1 overcapture
+              flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+            <field>
+              <name>CC2OF</name>
+              <description>Capture/compare 2 overcapture
+              flag</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>    
+          </fields>
+        </register>
+        <register>
+          <name>SWEVGR</name>
+          <displayName>SWEVGR</displayName>
+          <description>event generation register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>UG</name>
+              <description>Update generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC1G</name>
+              <description>Capture/compare 1
+              generation</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>CC2G</name>
+              <description>Capture/compare 2
+              generation</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>
+			<field>
+              <name>TG</name>
+              <description>Trigger generation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>write-only</access>
+            </field>         
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR1_Output</name>
+          <displayName>CHCTLR1_Output</displayName>
+          <description>capture/compare mode register 1 (output
+          mode)</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC1S</name>
+              <description>Capture/Compare 1
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1FE</name>
+              <description>Output compare 1 fast
+              enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1PE</name>
+              <description>Output compare 1 preload
+              enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1M</name>
+              <description>Output compare 1 mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC1CE</name>
+              <description>Output compare 1 clear
+              enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2S</name>
+              <description>Capture/Compare 2
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2FE</name>
+              <description>Output compare 2 fast
+              enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2PE</name>
+              <description>Output compare 2 preload
+              enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>OC2M</name>
+              <description>Output compare 2 mode</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>OC2CE</name>
+              <description>Output compare 2 clear
+              enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>     
+          </fields>
+        </register>
+        <register>
+          <name>CHCTLR1_Input</name>
+          <displayName>CHCTLR1_Input</displayName>
+          <description>capture/compare mode register 1 (input
+          mode)</description>
+          <alternateRegister>CHCTLR1_Output</alternateRegister>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CC1S</name>
+              <description>Capture/Compare 1
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC1PSC</name>
+              <description>Input capture 1 prescaler</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC1F</name>
+              <description>Input capture 1 filter</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2S</name>
+              <description>Capture/compare 2
+              selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>IC2PSC</name>
+              <description>Input capture 2 prescaler</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>IC2F</name>
+              <description>Input capture 2 filter</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CCER</name>
+          <displayName>CCER</displayName>
+          <description>capture/compare enable
+          register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CC1E</name>
+              <description>Capture/Compare 1 output
+              enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC1P</name>
+              <description>Capture/Compare 1 output
+              Polarity</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>CC2E</name>
+              <description>Capture/Compare 2 output
+              enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2P</name>
+              <description>Capture/Compare 2 output
+              Polarity</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>  
+          </fields>
+        </register>
+        <register>
+          <name>CNT</name>
+          <displayName>CNT</displayName>
+          <description>counter</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CNT</name>
+              <description>counter value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PSC</name>
+          <displayName>PSC</displayName>
+          <description>prescaler</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PSC</name>
+              <description>Prescaler value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ATRLR</name>
+          <displayName>ATRLR</displayName>
+          <description>auto-reload register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>ATRLR</name>
+              <description>Auto-reload value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH1CVR</name>
+          <displayName>CH1CVR</displayName>
+          <description>capture/compare register 1</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH1CVR</name>
+              <description>Capture/Compare 1 value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CH2CVR</name>
+          <displayName>CH2CVR</displayName>
+          <description>capture/compare register 2</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>CH2CVR</name>
+              <description>Capture/Compare 2 value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>SPEC</name>
+          <displayName>SPEC</displayName>
+          <description>SPEC</description>
+          <addressOffset>0x50</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PWM_EN</name>
+              <description>PWM_EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC1</name>
+              <description>PWM_OC1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PWM_OC2</name>
+              <description>PWM_OC2</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>TOGGLE</name>
+              <description>TOGGLE</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>I2C1</name>
+      <description>Inter integrated circuit</description>
+      <groupName>I2C</groupName>
+      <baseAddress>0x40005400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>I2C1_EV</name>
+        <description>I2C1 event interrupt</description>
+        <value>30</value>
+      </interrupt>
+      <interrupt>
+        <name>I2C1_ER</name>
+        <description>I2C1 error interrupt</description>
+        <value>31</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>PE</name>
+              <description>Peripheral enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ENARP</name>
+              <description>ARP enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ENPEC</name>
+              <description>PEC enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ENGC</name>
+              <description>General call enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>NOSTRETCH</name>
+              <description>Clock stretching disable (Slave
+              mode)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>START</name>
+              <description>Start generation</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>STOP</name>
+              <description>Stop generation</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ACK</name>
+              <description>Acknowledge enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>POS</name>
+              <description>Acknowledge/PEC Position (for data
+              reception)</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>PEC</name>
+              <description>Packet error checking</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>SWRST</name>
+              <description>Software reset</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>  
+          </fields>
+        </register>
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>FREQ</name>
+              <description>Peripheral clock frequency</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ITERREN</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ITEVTEN</name>
+              <description>Event interrupt enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ITBUFEN</name>
+              <description>Buffer interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>DMAEN</name>
+              <description>DMA requests enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>LAST</name>
+              <description>DMA last transfer</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field> 
+          </fields>
+        </register>
+        <register>
+          <name>OADDR1</name>
+          <displayName>OADDR1</displayName>
+          <description>Own address register 1</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>ADD0</name>
+              <description>Interface address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ADD7_1</name>
+              <description>Interface address</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>ADD9_8</name>
+              <description>Interface address</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ADDMODE</name>
+              <description>Addressing mode (slave
+              mode)</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>             
+          </fields>
+        </register>
+        <register>
+          <name>OADDR2</name>
+          <displayName>OADDR2</displayName>
+          <description>Own address register 2</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>ENDUAL</name>
+              <description>Dual addressing mode
+              enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>ADD2</name>
+              <description>Interface address</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>  
+          </fields>
+        </register>
+        <register>
+          <name>DATAR</name>
+          <displayName>DATAR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DATAR</name>
+              <description>8-bit data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STAR1</name>
+          <displayName>STAR1</displayName>
+          <description>Status register 1</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>SB</name>
+              <description>Start bit (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>ADDR</name>
+              <description>Address sent (master mode)/matched
+              (slave mode)</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+			<field>
+              <name>BTF</name>
+              <description>Byte transfer finished</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>ADD10</name>
+              <description>10-bit header sent (Master
+              mode)</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>STOPF</name>
+              <description>Stop detection (slave
+              mode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>RxNE</name>
+              <description>Data register not empty
+              (receivers)</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>TxE</name>
+              <description>Data register empty
+              (transmitters)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+			<field>
+              <name>BERR</name>
+              <description>Bus error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+			<field>
+              <name>ARLO</name>
+              <description>Arbitration lost (master
+              mode)</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+			<field>
+              <name>AF</name>
+              <description>Acknowledge failure</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+			<field>
+              <name>OVR</name>
+              <description>Overrun/Underrun</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>
+            <field>
+              <name>PECERR</name>
+              <description>PEC Error in reception</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read/clear</access>
+            </field>   
+          </fields>
+        </register>
+        <register>
+          <name>STAR2</name>
+          <displayName>STAR2</displayName>
+          <description>Status register 2</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>MSL</name>
+              <description>Master/slave</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>BUSY</name>
+              <description>Bus busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>TRA</name>
+              <description>Transmitter/receiver</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>GENCALL</name>
+              <description>General call address (Slave
+              mode)</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+            <field>
+              <name>DUALF</name>
+              <description>Dual flag (Slave mode)</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>PEC</name>
+              <description>PEC</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CKCFGR</name>
+          <displayName>CKCFGR</displayName>
+          <description>Clock control register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>CCR</name>
+              <description>Clock control register in Fast/Standard
+              mode (Master mode)</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>DUTY</name>
+              <description>Fast mode duty cycle</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+            <field>
+              <name>F_S</name>
+              <description>I2C master mode selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>   
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SPI1</name>
+      <description>Serial peripheral interface</description>
+      <groupName>SPI</groupName>
+      <baseAddress>0x40013000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SPI1</name>
+        <description>SPI1 global interrupt</description>
+        <value>33</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>control register 1</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>BIDIMODE</name>
+              <description>Bidirectional data mode
+              enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BIDIOE</name>
+              <description>Output enable in bidirectional
+              mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCEN</name>
+              <description>Hardware CRC calculation
+              enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCNEXT</name>
+              <description>CRC transfer next</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFF</name>
+              <description>Data frame format</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXONLY</name>
+              <description>Receive only</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSM</name>
+              <description>Software slave management</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSI</name>
+              <description>Internal slave select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LSBFIRST</name>
+              <description>Frame format</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPE</name>
+              <description>SPI enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BR</name>
+              <description>Baud rate control</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>MSTR</name>
+              <description>Master selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock polarity</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock phase</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>control register 2</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>TXEIE</name>
+              <description>Tx buffer empty interrupt
+              enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>RX buffer not empty interrupt
+              enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSOE</name>
+              <description>SS output enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXDMAEN</name>
+              <description>Tx buffer DMA enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXDMAEN</name>
+              <description>Rx buffer DMA enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>status register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0002</resetValue>
+          <fields>
+            <field>
+              <name>BSY</name>
+              <description>Busy flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OVR</name>
+              <description>Overrun flag</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODF</name>
+              <description>Mode fault</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CRCERR</name>
+              <description>CRC error flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>UDR</name>
+              <description>Underrun flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHSIDE</name>
+              <description>Channel side</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>Transmit buffer empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXNE</name>
+              <description>Receive buffer not empty</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATAR</name>
+          <displayName>DATAR</displayName>
+          <description>data register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <access>read-write</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCR</name>
+          <displayName>CRCR</displayName>
+          <description>CRCR polynomial register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x10</size>
+          <access>read-write</access>
+          <resetValue>0x0007</resetValue>
+          <fields>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC polynomial register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCRCR</name>
+          <displayName>RCRCR</displayName>
+          <description>RX CRC register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x10</size>
+          <access>read-only</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>RXCRC</name>
+              <description>Rx CRC register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TCRCR</name>
+          <displayName>TCRCR</displayName>
+          <description>send CRC register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x10</size>
+          <access>read-only</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>TXCRC</name>
+              <description>Tx CRC register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       
+        <register>
+          <name>HSCR</name>
+          <displayName>HSCR</displayName>
+          <description>high speed control register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x10</size>
+          <access>write-only</access>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>HSRXEN</name>
+              <description>High speed mode read enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USART1</name>
+      <description>Universal synchronous asynchronous receiver
+      transmitter</description>
+      <groupName>USART</groupName>
+      <baseAddress>0x40013800</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USART1</name>
+        <description>USART1 global interrupt</description>
+        <value>32</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>Status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x000000C0</resetValue>
+          <fields>
+            <field>
+              <name>CTS</name>
+              <description>CTS flag</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>LBD</name>
+              <description>LIN break detection flag</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TXE</name>
+              <description>Transmit data register
+              empty</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TC</name>
+              <description>Transmission complete</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RXNE</name>
+              <description>Read data register not
+              empty</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IDLE</name>
+              <description>IDLE line detected</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ORE</name>
+              <description>Overrun error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>NE</name>
+              <description>Noise error flag</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FE</name>
+              <description>Framing error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PE</name>
+              <description>Parity error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATAR</name>
+          <displayName>DATAR</displayName>
+          <description>Data register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DR</name>
+              <description>Data value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BRR</name>
+          <displayName>BRR</displayName>
+          <description>Baud rate register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DIV_Mantissa</name>
+              <description>mantissa of USARTDIV</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>DIV_Fraction</name>
+              <description>fraction of USARTDIV</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>Control register 1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>UE</name>
+              <description>USART enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>M</name>
+              <description>Word length</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKE</name>
+              <description>Wakeup method</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PCE</name>
+              <description>Parity control enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PS</name>
+              <description>Parity selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEIE</name>
+              <description>PE interrupt enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEIE</name>
+              <description>TXE interrupt enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCIE</name>
+              <description>Transmission complete interrupt
+              enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNEIE</name>
+              <description>RXNE interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDLEIE</name>
+              <description>IDLE interrupt enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TE</name>
+              <description>Transmitter enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RE</name>
+              <description>Receiver enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RWU</name>
+              <description>Receiver wakeup</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SBK</name>
+              <description>Send break</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>Control register 2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LINEN</name>
+              <description>LIN mode enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STOP</name>
+              <description>STOP bits</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock polarity</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock phase</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LBCL</name>
+              <description>Last bit clock pulse</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LBDIE</name>
+              <description>LIN break detection interrupt
+              enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LBDL</name>
+              <description>lin break detection length</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADD</name>
+              <description>Address of the USART node</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR3</name>
+          <displayName>CTLR3</displayName>
+          <description>Control register 3</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CTSIE</name>
+              <description>CTS interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSE</name>
+              <description>CTS enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTSE</name>
+              <description>RTS enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAT</name>
+              <description>DMA enable transmitter</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAR</name>
+              <description>DMA enable receiver</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SCEN</name>
+              <description>Smartcard mode enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NACK</name>
+              <description>Smartcard NACK enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HDSEL</name>
+              <description>Half-duplex selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IRLP</name>
+              <description>IrDA low-power</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IREN</name>
+              <description>IrDA mode enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GPR</name>
+          <displayName>GPR</displayName>
+          <description>Guard time and prescaler
+          register</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>GT</name>
+              <description>Guard time value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>PSC</name>
+              <description>Prescaler value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="USART1">
+      <name>USART2</name>
+      <baseAddress>0x40004400</baseAddress>
+      <interrupt>
+        <name>USART2</name>
+        <description>USART2 global interrupt</description>
+        <value>39</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="USART1">
+      <name>USART3</name>
+      <baseAddress>0x40004800</baseAddress>
+      <interrupt>
+        <name>USART3</name>
+        <description>USART3 global interrupt</description>
+        <value>42</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="USART1">
+      <name>UART4</name>
+      <baseAddress>0x40004C00</baseAddress>
+      <interrupt>
+        <name>UART4</name>
+        <description>UART4 global interrupt</description>
+        <value>43</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <description>Analog to digital converter</description>
+      <groupName>ADC</groupName>
+      <baseAddress>0x40012400</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC1</name>
+        <description>ADC global interrupt</description>
+        <value>29</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>status register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>STRT</name>
+              <description>Regular channel start flag</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JSTRT</name>
+              <description>Injected channel start
+              flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JEOC</name>
+              <description>Injected channel end of
+              conversion</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOC</name>
+              <description>Regular channel end of
+              conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWD</name>
+              <description>Analog watchdog flag</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>control register 1</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            
+            <field>
+              <name>TKEYEN</name>
+              <description>TKEY enable, including TKEY_F and
+              TKEY_V</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDEN</name>
+              <description>Analog watchdog enable on regular
+              channels</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JAWDEN</name>
+              <description>Analog watchdog enable on injected
+              channels</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          
+            <field>
+              <name>DISCNUM</name>
+              <description>Discontinuous mode channel
+              count</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JDISCEN</name>
+              <description>Discontinuous mode on injected
+              channels</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DISCEN</name>
+              <description>Discontinuous mode on regular
+              channels</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JAUTO</name>
+              <description>Automatic injected group
+              conversion</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDSGL</name>
+              <description>Enable the watchdog on a single channel
+              in scan mode</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SCAN</name>
+              <description>Scan mode enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JEOCIE</name>
+              <description>Interrupt enable for injected
+              channels</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDIE</name>
+              <description>Analog watchdog interrupt
+              enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOCIE</name>
+              <description>Interrupt enable for EOC</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AWDCH</name>
+              <description>Analog watchdog channel select
+              bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>control register 2</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            
+            <field>
+              <name>SWSTART</name>
+              <description>Start conversion of regular
+              channels</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JSWSTART</name>
+              <description>Start conversion of injected
+              channels</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTTRIG</name>
+              <description>External trigger conversion mode for
+              regular channels</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTSEL</name>
+              <description>External event select for regular
+              group</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEXTTRIG</name>
+              <description>External trigger conversion mode for
+              injected channels</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>JEXTSEL</name>
+              <description>External event select for injected
+              group</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>ALIGN</name>
+              <description>Data alignment</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMA</name>
+              <description>Direct memory access mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CONT</name>
+              <description>Continuous conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADON</name>
+              <description>A/D converter ON / OFF</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPTR1_CHARGE1</name>
+          <displayName>SAMPTR1_CHARGE1</displayName>
+          <description>sample time register 1/TKEYx_CHARGE1</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SMP10_TKCG10</name>
+              <description>Channel 10 sample time
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP11_TKCG11</name>
+              <description>Channel 11 sample time
+              selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP12_TKCG12</name>
+              <description>Channel 12 sample time
+              selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP13_TKCG13</name>
+              <description>Channel 13 sample time
+              selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP14_TKCG14</name>
+              <description>Channel 14 sample time
+              selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP15_TKCG15</name>
+              <description>Channel 15 sample time
+              selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP16_TKCG16</name>
+              <description>Channel 16 sample time
+              selection</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP17_TKCG17</name>
+              <description>Channel 17 sample time
+              selection</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPTR2_CHARGE2</name>
+          <displayName>SAMPTR2_CHARGE2</displayName>
+          <description>sample time register 2/TKEYx_CHARGE2</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SMP0_TKCG0</name>
+              <description>Channel 0 sample time
+              selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP1_TKCG1</name>
+              <description>Channel 1 sample time
+              selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP2_TKCG2</name>
+              <description>Channel 2 sample time
+              selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP3_TKCG3</name>
+              <description>Channel 3 sample time
+              selection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP4_TKCG4</name>
+              <description>Channel 4 sample time
+              selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP5_TKCG5</name>
+              <description>Channel 5 sample time
+              selection</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP6_TKCG6</name>
+              <description>Channel 6 sample time
+              selection</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP7_TKCG7</name>
+              <description>Channel 7 sample time
+              selection</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP8_TKCG8</name>
+              <description>Channel 8 sample time
+              selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SMP9_TKCG9</name>
+              <description>Channel 9 sample time
+              selection</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOFR1</name>
+          <displayName>IOFR1</displayName>
+          <description>injected channel data offset register
+          x</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JOFFSET1</name>
+              <description>Data offset for injected channel
+              x</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOFR2</name>
+          <displayName>IOFR2</displayName>
+          <description>injected channel data offset register
+          x</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JOFFSET2</name>
+              <description>Data offset for injected channel
+              x</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOFR3</name>
+          <displayName>IOFR3</displayName>
+          <description>injected channel data offset register
+          x</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JOFFSET3</name>
+              <description>Data offset for injected channel
+              x</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IOFR4</name>
+          <displayName>IOFR4</displayName>
+          <description>injected channel data offset register
+          x</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JOFFSET4</name>
+              <description>Data offset for injected channel
+              x</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WDHTR</name>
+          <displayName>WDHTR</displayName>
+          <description>watchdog higher threshold
+          register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>HT</name>
+              <description>Analog watchdog higher
+              threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WDLTR</name>
+          <displayName>WDLTR</displayName>
+          <description>watchdog lower threshold
+          register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LT</name>
+              <description>Analog watchdog lower
+              threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RSQR1</name>
+          <displayName>RSQR1</displayName>
+          <description>regular sequence register 1</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>L</name>
+              <description>Regular channel sequence
+              length</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SQ16</name>
+              <description>16th conversion in regular
+              sequence</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ15</name>
+              <description>15th conversion in regular
+              sequence</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ14</name>
+              <description>14th conversion in regular
+              sequence</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ13</name>
+              <description>13th conversion in regular
+              sequence</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RSQR2</name>
+          <displayName>RSQR2</displayName>
+          <description>regular sequence register 2</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SQ12</name>
+              <description>12th conversion in regular
+              sequence</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ11</name>
+              <description>11th conversion in regular
+              sequence</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ10</name>
+              <description>10th conversion in regular
+              sequence</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ9</name>
+              <description>9th conversion in regular
+              sequence</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ8</name>
+              <description>8th conversion in regular
+              sequence</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ7</name>
+              <description>7th conversion in regular
+              sequence</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RSQR3</name>
+          <displayName>RSQR3</displayName>
+          <description>regular sequence register 3</description>
+          <addressOffset>0x34</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SQ6</name>
+              <description>6th conversion in regular
+              sequence</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ5</name>
+              <description>5th conversion in regular
+              sequence</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ4</name>
+              <description>4th conversion in regular
+              sequence</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ3</name>
+              <description>3rd conversion in regular
+              sequence</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ2</name>
+              <description>2nd conversion in regular
+              sequence</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>SQ1</name>
+              <description>1st conversion in regular
+              sequence</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISQR</name>
+          <displayName>ISQR</displayName>
+          <description>injected sequence register</description>
+          <addressOffset>0x38</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JL</name>
+              <description>Injected sequence length</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>JSQ4</name>
+              <description>4th conversion in injected
+              sequence</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>JSQ3</name>
+              <description>3rd conversion in injected
+              sequence</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>JSQ2</name>
+              <description>2nd conversion in injected
+              sequence</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>JSQ1</name>
+              <description>1st conversion in injected
+              sequence</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDATAR1_CHGOFFSET</name>
+          <displayName>IDATAR1_CHGOFFSET</displayName>
+          <description>injected data register x_Charge data offset for injected channel x/TKEYx_CHGOFFSET</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JDATA0_7_TKCGOFFSET</name>
+              <description>Injected data_Touch key charge data offset for injected channel x</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>JDATA8_15</name>
+              <description>Injected data</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDATAR2</name>
+          <displayName>IDATAR2</displayName>
+          <description>injected data register x</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JDATA</name>
+              <description>Injected data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDATAR3</name>
+          <displayName>IDATAR3</displayName>
+          <description>injected data register x</description>
+          <addressOffset>0x44</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JDATA</name>
+              <description>Injected data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IDATAR4</name>
+          <displayName>IDATAR4</displayName>
+          <description>injected data register x</description>
+          <addressOffset>0x48</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>JDATA</name>
+              <description>Injected data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RDATAR_DR_ACT_DCG</name>
+          <displayName>RDATAR_DR_ACT_DCG</displayName>
+          <description>regular data register_start and discharge time register/TKEYx_DR/TKEYx_ACT_DCG</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>0x20</size>
+          <access>read-only_write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>DATA0_7_TKACT_DCG</name>
+              <description>Regular data_Touch key start and discharge time register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DATA8_15</name>
+              <description>Regular data</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DBG</name>
+      <description>Debug support</description>
+      <groupName>DBG</groupName>
+      <baseAddress>0xE000D000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CR</name>
+          <displayName>CR</displayName>
+          <description>DBGMCU_CR</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+			<field>
+              <name>SLEEP</name>
+              <description>SLEEP</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>STOP</name>
+              <description>STOP</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>STANDBY</name>
+              <description>STANDBY</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IWDG_STOP</name>
+              <description>IWDG_STOP</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WWDG_STOP</name>
+              <description>WWDG_STOP</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+
+            <field>
+              <name>TIM1_STOP</name>
+              <description>TIM1_STOP</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM2_STOP</name>
+              <description>TIM2_STOP</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TIM3_STOP</name>
+              <description>TIM3_STOP</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register> 
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USBFS</name>
+      <description>USB register</description>
+      <groupName>USBFS</groupName>
+      <baseAddress>0x40023400</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USBFS</name>
+        <description>USBFS</description>
+        <value>45</value>
+      </interrupt>
+      <interrupt>
+        <name>USBFS_WKUP</name>
+        <description>USBFS_WKUP</description>
+        <value>46</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>BASE_CTRL</name>
+          <description>USB base control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x08</size>
+          <access>read-write</access>
+          <resetValue>0x06</resetValue>
+          <fields>
+            <field>
+              <name>RB_UC_DMA_EN</name>
+              <description>DMA enable and DMA interrupt enable for USB</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UC_CLR_ALL</name>
+              <description>force clear FIFO and count of USB</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UC_RST_SIE</name>
+              <description>force reset USB SIE, need software clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UC_INT_BUSY</name>
+              <description>enable automatic responding busy for device mode or automatic pause for host mode during interrupt flag UIF_TRANSFER valid</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_SYS_MODE</name>
+              <description>RB_SYS_MODE</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RB_UC_LOW_SPEED</name>
+              <description>RB_UC_LOW_SPEED</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UC_HOST_MODE</name>
+              <description>enable USB host mode: 0=device mode, 1=host mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>HOST_CTRL_UDEV_CTRL</name>
+          <description>USB HOST control_UDEV_CTRL</description>
+          <addressOffset>0x01</addressOffset>
+          <size>0x08</size>
+		  <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>RB_UH_PORT_EN</name>
+              <description>RB_UH_PORT_EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RB_UH_BUS_RESET</name>
+              <description>RB_UH_BUS_RESET</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RB_UH_LOW_SPEED</name>
+              <description>RB_UH_LOW_SPEED</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RB_UH_DM_PIN</name>
+              <description>RB_UH_DM_PIN</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RB_UH_DP_PIN</name>
+              <description>RB_UH_DP_PIN</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RB_UH_PD_DIS</name>
+              <description>RB_UH_PD_DIS</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INT_EN</name>
+          <description>USB interrupt enable</description>
+          <addressOffset>0x02</addressOffset>
+          <size>0x08</size>
+          <access>read-write</access>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>RB_UIE_BUS_RST__RB_UIE_DETECT</name>
+              <description>enable interrupt for USB bus reset event for USB device mode;enable interrupt for USB device detected event for USB host mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_TRANSFER</name>
+              <description>enable interrupt for USB transfer completion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_SUSPEND</name>
+              <description>enable interrupt for USB suspend or resume event</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_SOF_ACT</name>
+              <description>indicate host SOF timer action status for USB host</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_FIFO_OV</name>
+              <description>enable interrupt for FIFO overflow</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_DEV_NAK</name>
+              <description>RB_UIE_DEV_NAK</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RB_UIE_DEV_SOF</name>
+              <description>RB_UIE_DEV_SOF</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DEV_ADDR</name>
+          <description>USB device address</description>
+          <addressOffset>0x03</addressOffset>
+          <size>0x08</size>
+          <access>read-write</access>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>MASK_USB_ADDR</name>
+              <description>bit mask for USB device address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MIS_ST</name>
+          <description>USB_MIS_ST</description>
+          <addressOffset>0x05</addressOffset>
+          <size>0x08</size>
+          <access>read-only</access>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>RB_UMS_DEV_ATTACH</name>
+              <description>RB_UMS_DEV_ATTACH</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_DM_LEVEL</name>
+              <description>RB_UMS_DM_LEVEL</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_SUSPEND</name>
+              <description>RB_UMS_SUSPEND</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_BUS_RST</name>
+              <description>RB_UMS_BUS_RST</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_R_FIFO_RDY</name>
+              <description>RB_UMS_R_FIFO_RDY</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_SIE_FREE</name>
+              <description>RB_UMS_SIE_FREE</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_SOF_ACT</name>
+              <description>RB_UMS_SOF_ACT</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RB_UMS_SOF_PRES</name>
+              <description>RB_UMS_SOF_PRES</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INT_FG</name>
+          <description>USB_INT_FG</description>
+          <addressOffset>0x06</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x20</resetValue>
+          <fields>
+            <field>
+              <name>RB_UIF_BUS_RST_RB_UIF_DETECT</name>
+              <description>RB_UIF_BUS_RST_RB_UIF_DETECT</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>RB_UIF_TRANSFER</name>
+              <description>RB_UIF_TRANSFER</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>RB_UIF_SUSPEND</name>
+              <description>RB_UIF_SUSPEND</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>RB_UIF_HST_SOF</name>
+              <description>RB_UIF_HST_SOF</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>RB_UIF_FIFO_OV</name>
+              <description>RB_UIF_FIFO_OV</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>RB_U_SIE_FREE</name>
+              <description>RB_U_SIE_FREE</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>TOG_MATCH_SYNC</name>
+              <description>TOG_MATCH_SYNC</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>RB_U_IS_NAK</name>
+              <description>RB_U_IS_NAK</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>INT_ST</name>
+          <description>USB_INT_ST</description>
+          <addressOffset>0x07</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>MASK_UIS_H_RES_MASK_UIS_ENDP</name>
+              <description>MASK_UIS_H_RES_MASK_UIS_ENDP</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>MASK_UIS_TOKEN</name>
+              <description>MASK_UIS_TOKEN</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>RB_UIS_TOG_OK</name>
+              <description>RB_UIS_TOG_OK</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+			<field>
+              <name>SETUP_ACT</name>
+              <description>SETUP_ACT</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RX_LEN</name>
+          <description>USB_RX_LEN</description>
+          <addressOffset>0x08</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>USB_RX_LEN</name>
+              <description>USB_RX_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP4_1_MOD</name>
+          <description>UEP4_1_MOD</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>0x08</size>
+		  <resetValue>0x00</resetValue>
+          <fields>
+			<field>
+              <name>EP4_T_EN</name>
+              <description>EP4_T_EN</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP4_R_EN</name>
+              <description>EP4_R_EN</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_BUF_MOD</name>
+              <description>EP1_BUF_MOD</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_T_EN</name>
+              <description>EP1_T_EN</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_R_EN</name>
+              <description>EP1_R_EN</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP2_3_MOD_HOST_EP_MOD</name>
+          <description>UEP2_3_MOD_HOST_EP_MOD</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>0x08</size>
+		  <resetValue>0x00</resetValue>
+          <fields>
+			<field>
+              <name>EP2_BUF_MOD_RB_UH_EP_RBUF_MOD</name>
+              <description>EP2_BUF_MOD_RB_UH_EP_RBUF_MOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_T_EN</name>
+              <description>EP2_T_EN</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_R_EN_RB_UH_EP_RX_EN</name>
+              <description>EP2_R_EN_RB_UH_EP_RX_EN</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_BUF_MOD_RB_UH_EP_TBUF_MOD</name>
+              <description>EP1_BUF_MOD_RB_UH_EP_TBUF_MOD</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_T_EN_RB_UH_EP_TX_EN</name>
+              <description>EP1_T_EN_RB_UH_EP_TX_EN</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_R_EN</name>
+              <description>EP1_R_EN</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP567_MOD</name>
+          <description>UEP567_MOD</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>0x08</size>
+		  <resetValue>0x00</resetValue>
+          <fields>
+			<field>
+              <name>EP5_T_EN</name>
+              <description>EP5_T_EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP5_R_EN</name>
+              <description>EP5_R_EN</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_T_EN</name>
+              <description>EP6_T_EN</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_R_EN</name>
+              <description>EP6_R_EN</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_T_EN</name>
+              <description>EP7_T_EN</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_R_EN</name>
+              <description>EP7_R_EN</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP0_DMA</name>
+          <description>UEP0_DMA</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0X20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP0_BUF_ADDR</name>
+              <description>EP0_BUF_ADDR</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP1_DMA</name>
+          <description>UEP1_DMA</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0X20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP1_BUF_ADDR</name>
+              <description>EP1_BUF_ADDR</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP2_DMA_HOST_RX_DMA</name>
+          <description>UEP2_DMA_HOST_RX_DMA</description>
+          <addressOffset>0x18</addressOffset>
+          <size>0X20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP2_BUF_ADDR_UH_RX_DMA</name>
+              <description>EP2_BUF_ADDR_UH_RX_DMA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP3_DMA_HOST_TX_DMA</name>
+          <description>UEP3_DMA_HOST_TX_DMA</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0X20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP3_BUF_ADDR_UH_TX_DMA</name>
+              <description>EP3_BUF_ADDR_UH_TX_DMA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP0_TX_LEN</name>
+          <description>UEP0_TX_LEN</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP0_T_LEN</name>
+              <description>EP0_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP0_CTRL_H</name>
+          <description>UEP0_CTRL_H</description>
+          <addressOffset>0x22</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP0_T_RES</name>
+              <description>EP0_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP0_R_RES</name>
+              <description>EP0_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP0_T_TOG</name>
+              <description>EP0_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP0_R_TOG</name>
+              <description>EP0_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP1_TX_LEN</name>
+          <description>UEP1_TX_LEN</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP1_T_LEN</name>
+              <description>EP1_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP1_CTRL_H_HOST_SETUP</name>
+          <description>UEP1_CTRL_H_HOST_SETUP</description>
+          <addressOffset>0x26</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP1_T_RES</name>
+              <description>EP1_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_R_RES</name>
+              <description>EP1_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_TOG_AUTO</name>
+              <description>EP1_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_T_TOG_RB_UH_SOF_EN</name>
+              <description>EP1_T_TOG_RB_UH_SOF_EN</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP1_R_TOG_RB_UH_PRE_PID_EN</name>
+              <description>EP1_R_TOG_RB_UH_PRE_PID_EN</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP2_TX_LEN</name>
+          <description>UEP2_TX_LEN</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP2_T_LEN</name>
+              <description>EP2_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP2_CTRL_H</name>
+          <description>UEP2_CTRL_H</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP2_T_RES</name>
+              <description>EP2_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_R_RES</name>
+              <description>EP2_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_TOG_AUTO</name>
+              <description>EP2_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_T_TOG</name>
+              <description>EP2_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP2_R_TOG</name>
+              <description>EP2_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP3_TX_LEN</name>
+          <description>UEP3_TX_LEN</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP3_T_LEN</name>
+              <description>EP3_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP3_CTRL_H</name>
+          <description>UEP3_CTRL_H</description>
+          <addressOffset>0x2E</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP3_T_RES</name>
+              <description>EP3_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_R_RES</name>
+              <description>EP3_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_TOG_AUTO</name>
+              <description>EP3_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_T_TOG</name>
+              <description>EP3_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP3_R_TOG</name>
+              <description>EP3_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP4_TX_LEN</name>
+          <description>UEP4_TX_LEN</description>
+          <addressOffset>0x30</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP4_T_LEN</name>
+              <description>EP4_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP4_CTRL_H</name>
+          <description>UEP4_CTRL_H</description>
+          <addressOffset>0x32</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP4_T_RES</name>
+              <description>EP4_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP4_R_RES</name>
+              <description>EP4_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP4_T_TOG</name>
+              <description>EP4_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP4_R_TOG</name>
+              <description>EP4_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UEP5_DMA</name>
+          <description>UEP5_DMA</description>
+          <addressOffset>0x54</addressOffset>
+          <size>0x20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP5_BUF_ADDR</name>
+              <description>EP5_BUF_ADDR</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP6_DMA</name>
+          <description>UEP6_DMA</description>
+          <addressOffset>0x58</addressOffset>
+          <size>0x20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP6_BUF_ADDR</name>
+              <description>EP6_BUF_ADDR</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP7_DMA</name>
+          <description>UEP7_DMA</description>
+          <addressOffset>0x5C</addressOffset>
+          <size>0x20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP7_BUF_ADDR</name>
+              <description>EP7_BUF_ADDR</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>15</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP5_TX_LEN</name>
+          <description>UEP5_TX_LEN</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP5_T_LEN</name>
+              <description>EP5_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP5_CTRL_H</name>
+          <description>UEP5_CTRL_H</description>
+          <addressOffset>0x66</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP5_T_RES</name>
+              <description>EP5_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP5_R_RES</name>
+              <description>EP5_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP5_TOG_AUTO</name>
+              <description>EP5_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP5_T_TOG</name>
+              <description>EP5_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP5_R_TOG</name>
+              <description>EP5_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP6_TX_LEN</name>
+          <description>UEP6_TX_LEN</description>
+          <addressOffset>0x68</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP6_T_LEN</name>
+              <description>EP6_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP6_CTRL_H</name>
+          <description>UEP6_CTRL_H</description>
+          <addressOffset>0x6A</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP6_T_RES</name>
+              <description>EP6_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_R_RES</name>
+              <description>EP6_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_TOG_AUTO</name>
+              <description>EP6_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_T_TOG</name>
+              <description>EP6_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP6_R_TOG</name>
+              <description>EP6_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP7_TX_LEN</name>
+          <description>UEP7_TX_LEN</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>EP7_T_LEN</name>
+              <description>EP7_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>UEP7_CTRL_H</name>
+          <description>UEP7_CTRL_H</description>
+          <addressOffset>0x6E</addressOffset>
+          <size>0x10</size>
+		  <resetValue>0x0000</resetValue>
+          <fields>
+			<field>
+              <name>EP7_T_RES</name>
+              <description>EP7_T_RES</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_R_RES</name>
+              <description>EP7_R_RES</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_TOG_AUTO</name>
+              <description>EP7_TOG_AUTO</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_T_TOG</name>
+              <description>EP7_T_TOG</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP7_R_TOG</name>
+              <description>EP7_R_TOG</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>USB_EPX_CTRL</name>
+          <description>USB_EPX_CTRL</description>
+          <addressOffset>0x70</addressOffset>
+          <size>0x20</size>
+		  <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>EP_T_LEN</name>
+              <description>EP5_T_LEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP_R_LEN</name>
+              <description>EP5_R_LEN</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+			  <access>read-write</access>
+            </field>
+			<field>
+              <name>EP_T_AF</name>
+              <description>EP_T_AF</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>7</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>FLASH</name>
+      <description>FLASH</description>
+      <groupName>FLASH</groupName>
+      <baseAddress>0x40022000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>FLASH</name>
+        <description>Flash global interrupt</description>
+        <value>18</value>
+      </interrupt>
+      <registers>
+		<register>
+          <name>ACTLR</name>
+          <displayName>ACTLR</displayName>
+          <description>Flash ACTL register</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>LATENCY</name>
+              <description>LATENCY</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+			  <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>KEYR</name>
+          <displayName>KEYR</displayName>
+          <description>Flash key register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>KEYR</name>
+              <description>FPEC key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OBKEYR</name>
+          <displayName>OBKEYR</displayName>
+          <description>Flash option key register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OPTKEY</name>
+              <description>Option byte key</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATR</name>
+          <displayName>STATR</displayName>
+          <description>Status register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>BOOT_LOCK</name>
+              <description>BOOT_LOCK</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BOOT_MODE</name>
+              <description>BOOT_MODE</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BOOT_STATUS</name>
+              <description>BOOT_STATUS</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOOT_AVA</name>
+              <description>BOOT_AVA</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+
+            <field>
+              <name>TURBO</name>
+              <description>TURBO mode start</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FWAKE_FLAG</name>
+              <description>FWAKE_FLAG mode start</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>EOP</name>
+              <description>End of operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>WRPRTERR</name>
+              <description>Write protection error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BSY</name>
+              <description>Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR</name>
+          <displayName>CTLR</displayName>
+          <description>Control register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000080</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Page Erase</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MER</name>
+              <description>Mass Erase</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBPG</name>
+              <description>Option byte programming</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBER</name>
+              <description>Option byte erase</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STRT</name>
+              <description>Start</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCK</name>
+              <description>Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OBWRE</name>
+              <description>Option bytes write enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERRIE</name>
+              <description>Error interrupt enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EOPIE</name>
+              <description>End of operation interrupt
+              enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FWAKEIE</name>
+              <description>Wakeup enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLOCK</name>
+              <description>Fast programmable lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FTPG</name>
+              <description>Fast programming</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FTER</name>
+              <description>Fast erase</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFLOAD</name>
+              <description>BUFLOAD</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFRST</name>
+              <description>BUFRST</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BER32</name>
+              <description>BER32</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+      
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <displayName>ADDR</displayName>
+          <description>Flash address register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>FAR</name>
+              <description>Flash Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OBR</name>
+          <displayName>OBR</displayName>
+          <description>Option byte register</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x03FFFFFC</resetValue>
+          <fields>
+            <field>
+              <name>OBERR</name>
+              <description>Option byte error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RDPRT</name>
+              <description>Read protection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IWDG_SW</name>
+              <description>IWDG_SW</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STOP_RST</name>
+              <description>STOP_RST</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STANDY_RST</name>
+              <description>STANDY_RST</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+
+            <field>
+              <name>CFGRSTT</name>
+              <description>Config reset delay time</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DATA0</name>
+              <description>DATA0</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DATA1</name>
+              <description>DATA1</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPR</name>
+          <displayName>WPR</displayName>
+          <description>Write protection register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>WRP</name>
+              <description>Write protect</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MODEKEYR</name>
+          <displayName>MODEKEYR</displayName>
+          <description>Mode select register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MODEKEYR</name>
+              <description>Mode select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>BOOT_MODEKEYP</name>
+          <displayName>BOOT_MODEKEYP</displayName>
+          <description>BOOT Mode select register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>MODEKEYR</name>
+              <description>Mode select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PFIC</name>
+      <description>Programmable Fast Interrupt
+      Controller</description>
+      <groupName>PFIC</groupName>
+      <baseAddress>0xE000E000</baseAddress>
+      <addressBlock>
+        <offset>0x00</offset>
+        <size>0x1100</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>ISR1</name>
+          <displayName>ISR1</displayName>
+          <description>Interrupt Status
+          Register</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x0000000C</resetValue>
+          <fields>
+            <field>
+              <name>INTENSTA2_3</name>
+              <description>Interrupt ID Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>INTENSTA12_31</name>
+              <description>Interrupt ID Status</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISR2</name>
+          <displayName>ISR2</displayName>
+          <description>Interrupt Status
+          Register</description>
+          <addressOffset>0x04</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTENSTA</name>
+              <description>Interrupt ID Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISR3</name>
+          <displayName>ISR3</displayName>
+          <description>Interrupt Status
+          Register</description>
+          <addressOffset>0x08</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTENSTA</name>
+              <description>Interrupt ID Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ISR4</name>
+          <displayName>ISR4</displayName>
+          <description>Interrupt Status
+          Register</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTENSTA</name>
+              <description>Interrupt ID Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPR1</name>
+          <displayName>IPR1</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x20</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSTA2_3</name>
+              <description>PENDSTA</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PENDSTA12_31</name>
+              <description>PENDSTA</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPR2</name>
+          <displayName>IPR2</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x24</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSTA</name>
+              <description>PENDSTA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPR3</name>
+          <displayName>IPR3</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x28</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSTA</name>
+              <description>PENDSTA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPR4</name>
+          <displayName>IPR4</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSTA</name>
+              <description>PENDSTA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ITHRESDR</name>
+          <displayName>ITHRESDR</displayName>
+          <description>Interrupt Priority
+          Register</description>
+          <addressOffset>0x40</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>THRESHOLD</name>
+              <description>THRESHOLD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CFGR</name>
+          <displayName>CFGR</displayName>
+          <description>Interrupt Config Register</description>
+          <addressOffset>0x48</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>RESETSYS</name>
+              <description>RESETSYS</description>
+              <access>write-only</access>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>KEYCODE</name>
+              <description>KEYCODE</description>
+              <access>write-only</access>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GISR</name>
+          <displayName>GISR</displayName>
+          <description>Interrupt Global Register</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>0x20</size>
+          <access>read-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>NESTSTA</name>
+              <description>NESTSTA</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>GACTSTA</name>
+              <description>GACTSTA</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GPENDSTA</name>
+              <description>GPENDSTA</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VTFIDR</name>
+          <displayName>VTFIDR</displayName>
+          <description>ID Config Register</description>
+          <addressOffset>0x50</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>VTFID0</name>
+              <description>VTFID0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>VTFID1</name>
+              <description>VTFID1</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>VTFID2</name>
+              <description>VTFID2</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>VTFID3</name>
+              <description>VTFID3</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VTFADDRR0</name>
+          <displayName>VTFADDRR0</displayName>
+          <description>Interrupt 0 address
+          Register</description>
+          <addressOffset>0x60</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>VTF0EN</name>
+              <description>VTF0EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name> ADDR0</name>
+              <description> ADDR0</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VTFADDRR1</name>
+          <displayName>VTFADDRR1</displayName>
+          <description>Interrupt 1 address
+          Register</description>
+          <addressOffset>0x64</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>VTF1EN</name>
+              <description>VTF1EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name> ADDR1</name>
+              <description> ADDR1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VTFADDRR2</name>
+          <displayName>VTFADDRR2</displayName>
+          <description>Interrupt 2 address
+          Register</description>
+          <addressOffset>0x68</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>VTF2EN</name>
+              <description>VTF2EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name> ADDR2</name>
+              <description> ADDR2</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VTFADDRR3</name>
+          <displayName>VTFADDRR3</displayName>
+          <description>Interrupt 3 address
+          Register</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>VTF3EN</name>
+              <description>VTF3EN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name> ADDR3</name>
+              <description> ADDR3</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IENR1</name>
+          <displayName>IENR1</displayName>
+          <description>Interrupt Setting Register</description>
+          <addressOffset>0x100</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTEN</name>
+              <description>INTEN</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IENR2</name>
+          <displayName>IENR2</displayName>
+          <description>Interrupt Setting Register</description>
+          <addressOffset>0x104</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTEN</name>
+              <description>INTEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IENR3</name>
+          <displayName>IENR3</displayName>
+          <description>Interrupt Setting Register</description>
+          <addressOffset>0x108</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTEN</name>
+              <description>INTEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IENR4</name>
+          <displayName>IENR4</displayName>
+          <description>Interrupt Setting Register</description>
+          <addressOffset>0x10C</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTEN</name>
+              <description>INTEN</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IRER1</name>
+          <displayName>IRER1</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x180</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTRSET</name>
+              <description>INTRSET</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IRER2</name>
+          <displayName>IRER2</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x184</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTRSET</name>
+              <description>INTRSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IRER3</name>
+          <displayName>IRER3</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x188</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTRSET</name>
+              <description>INTRSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IRER4</name>
+          <displayName>IRER4</displayName>
+          <description>Interrupt Clear Register</description>
+          <addressOffset>0x18C</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>INTRSET</name>
+              <description>INTRSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPSR1</name>
+          <displayName>IPSR1</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x200</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSET2_3</name>
+              <description>PENDSET</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PENDSET12_31</name>
+              <description>PENDSET</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPSR2</name>
+          <displayName>IPSR2</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x204</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSET</name>
+              <description>PENDSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPSR3</name>
+          <displayName>IPSR3</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x208</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSET</name>
+              <description>PENDSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPSR4</name>
+          <displayName>IPSR4</displayName>
+          <description>Interrupt Pending Register</description>
+          <addressOffset>0x20C</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDSET</name>
+              <description>PENDSET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPRR1</name>
+          <displayName>IPRR1</displayName>
+          <description>Interrupt Pending Clear Register</description>
+          <addressOffset>0x280</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDRESET2_3</name>
+              <description>PENDRESET</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>PENDRESET12</name>
+              <description>PENDRESET</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>PENDRESET14</name>
+              <description>PENDRESET</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>PENDRESET16_31</name>
+              <description>PENDRESET</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPRR2</name>
+          <displayName>IPRR2</displayName>
+          <description>Interrupt Pending Clear Register</description>
+          <addressOffset>0x284</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDRESET</name>
+              <description>PENDRESET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPRR3</name>
+          <displayName>IPRR3</displayName>
+          <description>Interrupt Pending Clear Register</description>
+          <addressOffset>0x288</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDRESET</name>
+              <description>PENDRESET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPRR4</name>
+          <displayName>IPRR4</displayName>
+          <description>Interrupt Pending Clear Register</description>
+          <addressOffset>0x28C</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>PENDRESET</name>
+              <description>PENDRESET</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IACTR1</name>
+          <displayName>IACTR1</displayName>
+          <description>Interrupt ACTIVE Register</description>
+          <addressOffset>0x300</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IACTS2_3</name>
+              <description>IACTS</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+			<field>
+              <name>IACTS12</name>
+              <description>IACTS</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>IACTS14</name>
+              <description>IACTS</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IACTS16_31</name>
+              <description>IACTS</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IACTR2</name>
+          <displayName>IACTR2</displayName>
+          <description>Interrupt ACTIVE Register</description>
+          <addressOffset>0x304</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IACTS</name>
+              <description>IACTS</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IACTR3</name>
+          <displayName>IACTR3</displayName>
+          <description>Interrupt ACTIVE Register</description>
+          <addressOffset>0x308</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IACTS</name>
+              <description>IACTS</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IACTR4</name>
+          <displayName>IACTR4</displayName>
+          <description>Interrupt ACTIVE Register</description>
+          <addressOffset>0x30C</addressOffset>
+          <size>0x20</size>
+          <access>write-only</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>IACTS</name>
+              <description>IACTS</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>IPRIOR0</name>
+          <displayName>IPRIOR0</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x400</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR1</name>
+          <displayName>IPRIOR1</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x401</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR2</name>
+          <displayName>IPRIOR2</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x402</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR3</name>
+          <displayName>IPRIOR3</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x403</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR4</name>
+          <displayName>IPRIOR4</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x404</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR5</name>
+          <displayName>IPRIOR5</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x405</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR6</name>
+          <displayName>IPRIOR6</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x406</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR7</name>
+          <displayName>IPRIOR7</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x407</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR8</name>
+          <displayName>IPRIOR8</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x408</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR9</name>
+          <displayName>IPRIOR9</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x409</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR10</name>
+          <displayName>IPRIOR10</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40A</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR11</name>
+          <displayName>IPRIOR11</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40B</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR12</name>
+          <displayName>IPRIOR12</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40C</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR13</name>
+          <displayName>IPRIOR13</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40D</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR14</name>
+          <displayName>IPRIOR14</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40E</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR15</name>
+          <displayName>IPRIOR15</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x40F</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR16</name>
+          <displayName>IPRIOR6</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x410</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR17</name>
+          <displayName>IPRIOR7</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x411</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR18</name>
+          <displayName>IPRIOR8</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x412</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR19</name>
+          <displayName>IPRIOR9</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x413</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR20</name>
+          <displayName>IPRIOR20</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x414</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR21</name>
+          <displayName>IPRIOR21</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x415</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR22</name>
+          <displayName>IPRIOR22</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x416</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR23</name>
+          <displayName>IPRIOR23</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x417</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR24</name>
+          <displayName>IPRIOR24</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x418</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR25</name>
+          <displayName>IPRIOR25</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x419</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR26</name>
+          <displayName>IPRIOR26</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41A</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR27</name>
+          <displayName>IPRIOR27</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41B</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR28</name>
+          <displayName>IPRIOR28</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41C</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR29</name>
+          <displayName>IPRIOR29</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41D</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR30</name>
+          <displayName>IPRIOR30</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41E</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR31</name>
+          <displayName>IPRIOR31</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x41F</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR32</name>
+          <displayName>IPRIOR32</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x420</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR33</name>
+          <displayName>IPRIOR33</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x421</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR34</name>
+          <displayName>IPRIOR34</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x422</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR35</name>
+          <displayName>IPRIOR35</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x423</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR36</name>
+          <displayName>IPRIOR36</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x424</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR37</name>
+          <displayName>IPRIOR37</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x425</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR38</name>
+          <displayName>IPRIOR38</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x426</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR39</name>
+          <displayName>IPRIOR39</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x427</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR40</name>
+          <displayName>IPRIOR40</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x428</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR41</name>
+          <displayName>IPRIOR41</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x429</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR42</name>
+          <displayName>IPRIOR42</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42A</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR43</name>
+          <displayName>IPRIOR43</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42B</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR44</name>
+          <displayName>IPRIOR44</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42C</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR45</name>
+          <displayName>IPRIOR45</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42D</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR46</name>
+          <displayName>IPRIOR46</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42E</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR47</name>
+          <displayName>IPRIOR47</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x42F</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR48</name>
+          <displayName>IPRIOR48</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x430</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR49</name>
+          <displayName>IPRIOR49</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x431</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR50</name>
+          <displayName>IPRIOR50</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x432</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR51</name>
+          <displayName>IPRIOR51</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x433</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR52</name>
+          <displayName>IPRIOR52</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x434</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR53</name>
+          <displayName>IPRIOR53</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x435</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR54</name>
+          <displayName>IPRIOR54</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x436</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR55</name>
+          <displayName>IPRIOR55</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x437</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR56</name>
+          <displayName>IPRIOR56</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x438</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR57</name>
+          <displayName>IPRIOR57</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x439</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR58</name>
+          <displayName>IPRIOR58</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43A</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR59</name>
+          <displayName>IPRIOR59</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43B</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR60</name>
+          <displayName>IPRIOR60</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43C</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR61</name>
+          <displayName>IPRIOR61</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43D</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR62</name>
+          <displayName>IPRIOR62</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43E</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>IPRIOR63</name>
+          <displayName>IPRIOR63</displayName>
+          <description>Interrupt Priority Register</description>
+          <addressOffset>0x43F</addressOffset>
+          <size>0x8</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+        </register>
+        <register>
+          <name>SCTLR</name>
+          <displayName>SCTLR</displayName>
+          <description>System Control Register</description>
+          <addressOffset>0xd10</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>SLEEPONEXIT</name>
+              <description>SLEEPONEXIT</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPDEEP</name>
+              <description>SLEEPDEEP</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WFITOWFE</name>
+              <description>WFITOWFE</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEVONPEND</name>
+              <description>SEVONPEND</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SETEVENT</name>
+              <description>SETEVENT</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+			<field>
+              <name>RSTEN</name>
+              <description>RSTEN</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSRESET</name>
+              <description>SYSRESET</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_CTLR</name>
+          <displayName>STK_CTLR</displayName>
+          <description>System counter control register</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>STE</name>
+              <description>System counter  enable</description>
+              <access>read-write</access>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STIE</name>
+              <description>System counter interrupt enable</description>
+              <access>read-write</access>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STCLK</name>
+              <description>System selects the clock source</description>
+              <access>read-write</access>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STRE</name>
+              <description>System reload register</description>
+              <access>read-write</access>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>System Mode</description>
+              <access>read-write</access>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWIE</name>
+              <description>System software triggered interrupts enable</description>
+              <access>read-write</access>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_SR</name>
+          <description>System START</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNTIF</name>
+              <description>CNTIF</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_CNTL</name>
+          <description>System counter low register</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNTL</name>
+              <description>CNTL</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_CNTH</name>
+          <description>System counter high register</description>
+          <addressOffset>0x100C</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CNTH</name>
+              <description>CNTH</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_CMPLR</name>
+          <description>System compare low register</description>
+          <addressOffset>0x1010</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CMPL</name>
+              <description>CMPL</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STK_CMPHR</name>
+          <description>System compare high register</description>
+          <addressOffset>0x1014</addressOffset>
+          <size>0x20</size>
+          <access>read-write</access>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CMPH</name>
+              <description>CMPH</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+
+    <peripheral>
+      <name>AWU</name>
+      <description> AWU configuration</description>
+      <groupName>AWU</groupName>
+      <baseAddress>0x40026400</baseAddress>
+
+      <interrupt>
+        <name>AWU</name>
+        <description>AWU global interrupt</description>
+        <value>21</value>
+      </interrupt>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>R16_AWU_CSR</name>
+          <displayName>R16_AWU_CSR</displayName>
+          <description>Status Control register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>AWUEN</name>
+              <description>AWU Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>R16_AWU_WR</name>
+          <displayName>R16_AWU_WR</displayName>
+          <description>AWU Window register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x003F</resetValue>
+          <fields>
+            <field>
+              <name>AWU_APR</name>
+              <description>AWU_APR value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>R16_AWU_PSC</name>
+          <displayName>R16_AWU_PSC</displayName>
+          <description>R16_AWU_PSC</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>AWU_TBR</name>
+              <description>AWU_TBR value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+
+    <peripheral>
+      <name>OPA</name>
+      <description> OPA configuration</description>
+      <groupName>OPA</groupName>
+      <baseAddress>0x40026000</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CFGR1</name>
+          <displayName>CFGR1</displayName>
+          <description>OPA Configuration register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>POLL_EN1</name>
+              <description>POLL_EN1 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>POLL_EN2</name>
+              <description>POLL_EN2 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKIN_EN1</name>
+              <description>BKIN_EN1 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>BKIN_EN2</name>
+              <description>BKIN_EN2 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>RST_EN1</name>
+              <description>RST_EN1 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>RST_EN2</name>
+              <description>RST_EN2 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BKIN_SEL</name>
+              <description>BKIN_SEL select</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>POLL_LOCK</name>
+              <description>POLL_LOCK select</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_OUT1</name>
+              <description>IE_OUT1 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>IE_OUT2</name>
+              <description>IE_OUT2 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_CNT</name>
+              <description>IE_CNT Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NMI_EN</name>
+              <description>NMI_EN Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_OUT1</name>
+              <description>IF_OUT1 Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_OUT2</name>
+              <description>IF_OUT2 Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_CNT</name>
+              <description>IF_CNT Configuration</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+		<register>
+          <name>CFGR2</name>
+          <displayName>CFGR2</displayName>
+          <description>OPA Configuration register</description>
+          <addressOffset>0x2</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>POLL_VLU</name>
+              <description>POLL_VLU Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>            
+            <field>
+              <name>POLL1_NUM</name>
+              <description>POLL1_NUM Configuration</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>POLL2_NUM</name>
+              <description>POLL2_NUM Configuration</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTLR1</name>
+          <displayName>CTLR1</displayName>
+          <description>OPA Control1 register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x81D801D8</resetValue>
+          <fields>
+            <field>
+              <name>EN1</name>
+              <description>OPA1 enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>OPA1 mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PSEL1</name>
+              <description>Input select</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>FB_EN1</name>
+              <description>res inside enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NSEL1</name>
+              <description>output select</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+
+            <field>
+              <name>EN2</name>
+              <description>OPA2 enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>OPA2 mode</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PSEL2</name>
+              <description>Input select</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>FB_EN2</name>
+              <description>res inside enable</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NSEL2</name>
+              <description>output select</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+
+            <field>
+              <name>OPA_LOCK</name>
+              <description>OPA_LOCK</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>CTLR2</name>
+          <displayName>CTLR2</displayName>
+          <description>OPA Control2 register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x80000000</resetValue>
+          <fields>
+            <field>
+              <name>EN1</name>
+              <description>CMP1 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE1</name>
+              <description>CMP1 OUT Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NSEL1</name>
+              <description>CMP1 IN_N Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PSEL1</name>
+              <description>CMP1 IN_P Selection</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>HYEN1</name>
+              <description>CMP1 HYEN Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+			<field>
+              <name>EN2</name>
+              <description>CMP2 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE2</name>
+              <description>CMP2 OUT Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NSEL2</name>
+              <description>CMP2 IN_N Selection</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PSEL2</name>
+              <description>CMP2 IN_P Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HYEN2</name>
+              <description>CMP2 HYEN Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>EN3</name>
+              <description>CMP3 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>MODE3</name>
+              <description>CMP3 OUT Selection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>NSEL3</name>
+              <description>CMP3 IN_N Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PSEL3</name>
+              <description>CMP3 IN_P Selection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>HYEN3</name>
+              <description>CMP3 HYEN Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+
+            <field>
+              <name>CMP_LOCK</name>
+              <description>CMP_LOCK</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>OPA_KEY</name>
+          <displayName>OPA_KEY</displayName>
+          <description>OPA unlock key register</description>
+          <addressOffset>0x0c</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>OPA_KEY</name>
+              <description>OPA_KEY value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>CMP_KEY</name>
+          <displayName>CMP_KEY</displayName>
+          <description>CMP unlock key register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>CMP_KEY</name>
+              <description>CMP_KEY value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>POLL_KEY</name>
+          <displayName>POLL_KEY</displayName>
+          <description>POLL unlock key register</description>
+          <addressOffset>0x14</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>POLL_KEY</name>
+              <description>POLL_KEY value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+
+    <peripheral>
+      <name>ESIG</name>
+      <description> ESIG configuration</description>
+      <groupName>ESIG</groupName>
+      <baseAddress>0x1FFFF7E0</baseAddress>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>FLACAP</name>
+          <displayName>FLACAP</displayName>
+          <description>Flash capecity register</description>
+          <addressOffset>0x0</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>F_SIZE</name>
+              <description>F_SIZE/kByte</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>UNIID1</name>
+          <displayName>UNIID1</displayName>
+          <description>UID register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>U_ID</name>
+              <description>U_ID value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>UNIID2</name>
+          <displayName>UNIID2</displayName>
+          <description>UID register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>U_ID</name>
+              <description>U_ID value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+
+        <register>
+          <name>UNIID3</name>
+          <displayName>UNIID3</displayName>
+          <description>Div register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x20</size>
+          <resetValue>0x00000000</resetValue>
+          <fields>
+            <field>
+              <name>AWU_APR</name>
+              <description>AWU_APR value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+
+    <peripheral>
+      <name>USBPD</name>
+      <description> USBPD configuration</description>
+      <groupName>USBPD</groupName>
+      <baseAddress>0x40027000</baseAddress>
+
+       <interrupt>
+        <name>USBPD_WKUP</name>
+        <description>USBPD_WKUP global interrupt</description>
+        <value>50</value>
+      </interrupt>
+
+      <interrupt>
+        <name>USBPD</name>
+        <description>USBPD global interrupt</description>
+        <value>49</value>
+      </interrupt>
+      <addressBlock>
+        <offset>0x0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CONFIG</name>
+          <displayName>CONFIG</displayName>
+		  <description>PD interrupt enable register</description>
+          <addressOffset>0x00</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PD_ALL_CLR</name>
+              <description>PD ITClear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC_SEL</name>
+              <description>PD Commutation port</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PD_DMA_EN</name>
+              <description>PD DMA Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>PD_RST_EN</name>
+              <description>PD RST Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>WAKE_POLAR</name>
+              <description>wakeup polarity</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_PD_IO</name>
+              <description>IO Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_RX_BIT</name>
+              <description>bit interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_RX_BYTE</name>
+              <description>Receive byte register</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_RX_ACT</name>
+              <description>Receive complete register</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_RX_RESET</name>
+              <description>Receive complete rst register</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IE_TX_END</name>
+              <description>transfer complete register</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BMC_CLK_CNT</name>
+          <displayName>BMC_CLK_CNT</displayName>
+		  <description>BMC sampling clock counter</description>
+          <addressOffset>0x02</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>BMC_CLK_CNT</name>
+              <description>R/T counter</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONTROL</name>
+          <displayName>CONTROL</displayName>
+		  <description>PD Send and receive enable register</description>
+          <addressOffset>0x4</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>PD_TX_EN</name>
+              <description>PD_TX_EN value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BMC_START</name>
+              <description>BMC_START value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>DATA_FLAG</name>
+              <description>DATA_FLAG value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TX_BIT_BACK</name>
+              <description>TX_BIT_BACK value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BMC_BYTE_HI</name>
+              <description>BMC_BYTE_HI value</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>TX_SEL</name>
+          <displayName>TX_SEL</displayName>
+		  <description>SOP port selection register</description>
+          <addressOffset>0x5</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>TX_SEL1</name>
+              <description>TX_SEL1 value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TX_SEL2</name>
+              <description>TX_SEL2 value</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TX_SEL3</name>
+              <description>TX_SEL3 value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>TX_SEL4</name>
+              <description>TX_SEL4 value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BMC_TX_SZ</name>
+          <displayName>BMC_TX_SZ</displayName>
+		  <description>PD send length register</description>
+          <addressOffset>0x6</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>BMC_TX_SZ</name>
+              <description>BMC_TX_SZ value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>      
+        <register>
+          <name>DATA_BUF</name>
+          <displayName>DATA_BUF</displayName>
+		  <description>DMA cache data register</description>
+          <addressOffset>0x8</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>DATA_BUF</name>
+              <description>DATA_BUF value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <displayName>STATUS</displayName>
+		  <description>PD interrupt flag register</description>
+          <addressOffset>0x9</addressOffset>
+          <size>0x08</size>
+          <resetValue>0x00</resetValue>
+          <fields>
+            <field>
+              <name>BMC_AUX</name>
+              <description>BMC_AUX value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>BUF_ERR</name>
+              <description>BUF_ERR value</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_RX_BIT</name>
+              <description>IF_RX_BIT value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_RX_BYTE</name>
+              <description>IF_RX_BYTE value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_RX_ACT</name>
+              <description>IF_RX_ACT value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_RX_RESET</name>
+              <description>IF_RX_RESET value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>IF_TX_END</name>
+              <description>IF_TX_END value</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BMC_BYTE_CNT</name>
+          <displayName>BMC_BYTE_CNT</displayName>
+		  <description>Byte counter</description>
+          <addressOffset>0xA</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>BMC_BYTE_CNT</name>
+              <description>BMC_BYTE_CNT value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PORT_CC1</name>
+          <displayName>PORT_CC1</displayName>
+		  <description>CC1 port control register</description>
+          <addressOffset>0xC</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PA_CC1_AI</name>
+              <description>PA_CC1_AI value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CC1_PU</name>
+              <description>CC1_PU value</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1_LV0</name>
+              <description>CC1_LV0 value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC1_CE</name>
+              <description>CC1_CE value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PORT_CC2</name>
+          <displayName>PORT_CC2</displayName>
+		  <description>CC2 port control register</description>
+          <addressOffset>0xE</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>PA_CC2_AI</name>
+              <description>PA_CC2_AI value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2_PU</name>
+              <description>CC2_PU value</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2_LV0</name>
+              <description>CC2_LV0 value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-write</access>
+            </field>
+            <field>
+              <name>CC2_CE</name>
+              <description>CC2_CE value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DMA</name>
+          <displayName>DMA</displayName>
+		  <description>PD buffer start address register</description>
+          <addressOffset>0x10</addressOffset>
+          <size>0x10</size>
+          <resetValue>0x0000</resetValue>
+          <fields>
+            <field>
+              <name>USBPD_DMA_ADDR</name>
+              <description>USBPD_DMA_ADDR value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-write</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+
+  </peripherals>
+</device>

--- a/platform.json
+++ b/platform.json
@@ -1,6 +1,6 @@
 {
   "name": "ch32v",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "title": "WCH CH32V",
   "description": "CH32V series are industrial-grade general-purpose microcontrollers designed based on QingKe 32-bit RISC-V.",
   "homepage": "https://www.wch.cn/",


### PR DESCRIPTION
Could you please add support for CH32X035?

relation: https://github.com/Community-PIO-CH32V/framework-wch-noneos-sdk/pull/1

The svd file was copied from MounRiver_Studio_Community_V150.
http://www.mounriver.com/download
http://file.mounriver.com/upgrade/MounRiver_Studio_Community_Linux_x64_V150.tar.xz
MRS_Community/template/wizard/WCH/RISC-V/CH32X035/NoneOS/CH32X035.svd

We have confirmed that we can actually build and upload on the CH32X035 development board.
https://github.com/74th/ch32x035-testing/tree/main/blink-pio