### PR TITLE
Add RT-Thread support for CH59x

### DIFF
--- a/boards/genericCH591D.json
+++ b/boards/genericCH591D.json
@@ -22,7 +22,8 @@
   },
   "frameworks": [
     "noneos-sdk",
-    "freertos"
+    "freertos",
+    "rt-thread"
   ],
   "name": "Generic CH591D",
   "upload": {

--- a/boards/genericCH591F.json
+++ b/boards/genericCH591F.json
@@ -22,7 +22,8 @@
   },
   "frameworks": [
     "noneos-sdk",
-    "freertos"
+    "freertos",
+    "rt-thread"
   ],
   "name": "Generic CH591F",
   "upload": {

--- a/boards/genericCH591R.json
+++ b/boards/genericCH591R.json
@@ -22,7 +22,8 @@
   },
   "frameworks": [
     "noneos-sdk",
-    "freertos"
+    "freertos",
+    "rt-thread"
   ],
   "name": "Generic CH591R",
   "upload": {

--- a/boards/genericCH592F.json
+++ b/boards/genericCH592F.json
@@ -22,7 +22,8 @@
   },
   "frameworks": [
     "noneos-sdk",
-    "freertos"
+    "freertos",
+    "rt-thread"
   ],
   "name": "Generic CH592F",
   "upload": {

--- a/boards/genericCH592X.json
+++ b/boards/genericCH592X.json
@@ -22,7 +22,8 @@
   },
   "frameworks": [
     "noneos-sdk",
-    "freertos"
+    "freertos",
+    "rt-thread"
   ],
   "name": "Generic CH592X",
   "upload": {

--- a/examples/hello-world-rt-thread-ch5xx/platformio.ini
+++ b/examples/hello-world-rt-thread-ch5xx/platformio.ini
@@ -21,3 +21,6 @@ upload_protocol = isp
 
 [env:genericCH582F]
 board = genericCH582F
+
+[env:genericCH592F]
+board = genericCH592F

--- a/examples/hello-world-rt-thread-ch5xx/src/main.c
+++ b/examples/hello-world-rt-thread-ch5xx/src/main.c
@@ -10,7 +10,12 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
+
+#if defined(CH58X)
 #include "CH58x_common.h"
+#elif defined(CH59X)
+#include "CH59x_common.h"
+#endif
 #include <rtthread.h>
 
 ALIGN(RT_ALIGN_SIZE)

--- a/misc/scripts/gen_boarddefs.py
+++ b/misc/scripts/gen_boarddefs.py
@@ -292,6 +292,7 @@ def create_board_json(info: ChipInfo, board_name:str, output_path: str, patch_in
         base_json["frameworks"].append("rt-thread")
     if chip_l.startswith("ch59"):
         base_json["frameworks"].append("freertos")
+        base_json["frameworks"].append("rt-thread")
     if chip_l.startswith("ch32v003"):
         base_json["frameworks"].append("arduino")
         base_json["build"]["core"] = "ch32v003"


### PR DESCRIPTION
This PR adds RT-Thread support for CH59x and updates existing example. SDK added here: https://github.com/Community-PIO-CH32V/framework-wch-rtthread/pull/1