### PR TITLE
Add flush size on TinyUSB example

### DIFF
--- a/examples/tinyusb-arduino/platformio.ini
+++ b/examples/tinyusb-arduino/platformio.ini
@@ -16,15 +16,17 @@ board_build.core = openwch
 ; uncomment this to use USB bootloader upload via WCHISP
 ;upload_protocol = isp
 
-[env:genericCH32V203C6T6_no_usb]
-board = genericCH32V203C6T6
+[env:genericCH32V203C8T6_no_usb]
+board = genericCH32V203C8T6
 
-[env:genericCH32V203C6T6_tinyusb_usbd]
-board = genericCH32V203C6T6
+; needs a chip with 64K FLASH, not 32K
+[env:genericCH32V203C8T6_tinyusb_usbd]
+board = genericCH32V203C8T6
 build_flags = -DPIO_FRAMEWORK_ARDUINO_USBD
 
-[env:genericCH32V203C6T6_tinyusb_usbfs]
-board = genericCH32V203C6T6
+; needs a chip with 64K FLASH, not 32K
+[env:genericCH32V203C8T6_tinyusb_usbfs]
+board = genericCH32V203C8T6
 build_flags = -DPIO_FRAMEWORK_ARDUINO_USBFS
 
 [env:ch32v307_evt_no_usb]


### PR DESCRIPTION
Running the TinyUSB test on the CH32V203C6T6 may result in insufficient Flush. I have changed the board used for testing to CH32V203C8T6 which has 64KB flash size.

```
Checking size .pio/build/genericCH32V203C6T6_tinyusb_usbd/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=====     ]  47.1% (used 4824 bytes from 10240 bytes)
Error: The program size (34644 bytes) is greater than maximum allowed (32768 bytes)
Flash: [==========]  105.7% (used 34644 bytes from 32768 bytes)
*** [checkprogsize] Explicit exit, status 1

========================== [FAILED] Took 6.29 seconds ==========================
```