### PR TITLE
README: update udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ If you use Mac, the usage of a Linux virtual machine may be required to run thes
 4. For Linux, add PlatformIO per [documentation](https://docs.platformio.org/en/latest/core/installation/udev-rules.html#platformio-udev-rules). Then, add WCH udev rules by appending the following content to `etc/udev/rules.d/99-platformio-udev.rules`.
 
 ```
-SUBSYSTEM=="usb", ATTR{idVendor}="1a86", ATTR{idProduct}=="8010", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTR{idVendor}="4348", ATTR{idProduct}=="55e0", GROUP="plugdev"
-SUBSYSTEM=="usb", ATTR{idVendor}="1a86", ATTR{idProduct}=="8012", GROUP="plugdev"
+SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", GROUP:="plugdev"
+SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="4348", ATTRS{idProduct}=="55e0", GROUP:="plugdev"
+SUBSYSTEM=="usb|tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8012", GROUP:="plugdev"
 ```
 
 **Without these udev rules or the missing group membership of the user in the plugdev group, accessing the WCH-Link(E) via OpenOCD or wchisp will not work!!**


### PR DESCRIPTION
`tty` devices also deserve being in `plugdev` group, so `cu` and `minicom` work without root.

This commit also fixes a typo `=` vs. `==`.