### PR TITLE
CH32H4: Arduino core for the CH32H417QEU6 EVT board

### DIFF
--- a/boards/ch32h417qeu6_evt_r0.json
+++ b/boards/ch32h417qeu6_evt_r0.json
@@ -17,7 +17,7 @@
     "series": "ch32h417",
     "spl_series": "ch32h417",
     "variant": "CH32H417QEU6_EVT_R0",
-    "package": "CH32H417xx_QEU6"
+    "package": "CH32H417QEU6"
   },
   "debug": {
     "onboard_tools": [

--- a/boards/ch32h417qeu6_evt_r0.json
+++ b/boards/ch32h417qeu6_evt_r0.json
@@ -16,7 +16,8 @@
     "mcu": "ch32h417qeu6",
     "series": "ch32h417",
     "spl_series": "ch32h417",
-    "variant": "CH32H417QEU6"
+    "variant": "CH32H417QEU6_EVT_R0",
+    "package": "CH32H417xx_QEU6"
   },
   "debug": {
     "onboard_tools": [

--- a/boards/ch32h417qeu6_evt_r0.json
+++ b/boards/ch32h417qeu6_evt_r0.json
@@ -1,0 +1,42 @@
+{
+  "build": {
+    "core": "ch32h4",
+    "cpu_core": "v3f",
+    "clock_source": "hse+pll",
+    "extra_flags": "-DCH32H417 -DCH32H41x -DARDUINO_ARCH_CH32H4",
+    "f_cpu": "400000000L",
+    "hwids": [
+      [
+        "0x1A86",
+        "0x8010"
+      ]
+    ],
+    "mabi": "ilp32f",
+    "march": "rv32imafc_zba_zbb_zbc_zbs_xw",
+    "mcu": "ch32h417qeu6",
+    "series": "ch32h417",
+    "spl_series": "ch32h417",
+    "variant": "CH32H417QEU6"
+  },
+  "debug": {
+    "onboard_tools": [
+      "wch-link"
+    ],
+    "openocd_config": "wch-riscv.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "CH32H417QEU6-R0-1v1",
+  "upload": {
+    "maximum_ram_size": 917504,
+    "maximum_size": 933888,
+    "protocol": "wch-link",
+    "protocols": [
+      "wch-link",
+      "isp"
+    ]
+  },
+  "url": "https://www.wch-ic.com/products/CH32H417.html",
+  "vendor": "WCH"
+}

--- a/boards/genericCH32H415REU6.json
+++ b/boards/genericCH32H415REU6.json
@@ -1,0 +1,43 @@
+{
+  "build": {
+    "clock_source": "hsi+pll",
+    "extra_flags": "-DCH32H415RE -DCH32H41X -DCH32H41x -DCH32H415",
+    "f_cpu": "400000000L",
+    "hwids": [
+      [
+        "0x1A86",
+        "0x8010"
+      ]
+    ],
+    "mabi": "ilp32",
+    "march": "rv32imac_zba_zbb_zbc_zbs_xw",
+    "mcu": "ch32h415reu6",
+    "series": "ch32h417",
+    "spl_series": "ch32h417"
+  },
+  "debug": {
+    "onboard_tools": [
+      "wch-link"
+    ],
+    "openocd_config": "wch-dual-core.cfg",
+    "svd_path": "CH32H417xx.svd"
+  },
+  "frameworks": [
+    "noneos-sdk",
+    "ch32v003fun"
+  ],
+  "name": "Generic CH32H415REU6",
+  "upload": {
+    "maximum_ram_size": 131072,
+    "maximum_size": 983040,
+    "protocol": "wch-link",
+    "protocols": [
+      "wch-link",
+      "minichlink",
+      "isp",
+      "wlink"
+    ]
+  },
+  "url": "http://www.wch-ic.com/products/CH32H417.html",
+  "vendor": "W.CH"
+}

--- a/boards/genericCH32H415REU6_V3F.json
+++ b/boards/genericCH32H415REU6_V3F.json
@@ -1,7 +1,8 @@
 {
   "build": {
     "clock_source": "hsi+pll",
-    "extra_flags": "-DCH32H417RE -DCH32H41X -DCH32H41x -DCH32H417",
+    "cpu_core": "v3f",
+    "extra_flags": "-DCH32H415RE -DCH32H41X -DCH32H41x -DCH32H415 -DCore_V3F",
     "f_cpu": "400000000L",
     "hwids": [
       [
@@ -11,7 +12,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imac_zba_zbb_zbc_zbs_xw",
-    "mcu": "ch32h417reu6",
+    "mcu": "ch32h415reu6",
     "series": "ch32h417",
     "spl_series": "ch32h417"
   },
@@ -26,7 +27,7 @@
     "noneos-sdk",
     "ch32v003fun"
   ],
-  "name": "Generic CH32H417REU6",
+  "name": "Generic CH32H415REU6 (V3F Master)",
   "upload": {
     "maximum_ram_size": 131072,
     "maximum_size": 983040,

--- a/boards/genericCH32H415REU6_V5F.json
+++ b/boards/genericCH32H415REU6_V5F.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "clock_source": "hsi+pll",
+    "cpu_core": "v5f",
+    "extra_flags": "-DCH32H415RE -DCH32H41X -DCH32H41x -DCH32H415 -DCore_V5F",
+    "f_cpu": "400000000L",
+    "hwids": [
+      [
+        "0x1A86",
+        "0x8010"
+      ]
+    ],
+    "mabi": "ilp32",
+    "march": "rv32imac_zba_zbb_zbc_zbs_xw",
+    "mcu": "ch32h415reu6",
+    "series": "ch32h417",
+    "spl_series": "ch32h417"
+  },
+  "debug": {
+    "onboard_tools": [
+      "wch-link"
+    ],
+    "openocd_config": "wch-dual-core.cfg",
+    "svd_path": "CH32H417xx.svd"
+  },
+  "frameworks": [
+    "noneos-sdk",
+    "ch32v003fun"
+  ],
+  "name": "Generic CH32H415REU6 (V5F Slave)",
+  "upload": {
+    "maximum_ram_size": 131072,
+    "maximum_size": 983040,
+    "protocol": "wch-link",
+    "protocols": [
+      "wch-link",
+      "minichlink",
+      "isp",
+      "wlink"
+    ]
+  },
+  "url": "http://www.wch-ic.com/products/CH32H417.html",
+  "vendor": "W.CH"
+}

--- a/boards/genericCH32H416RDU6.json
+++ b/boards/genericCH32H416RDU6.json
@@ -1,8 +1,7 @@
 {
   "build": {
     "clock_source": "hsi+pll",
-    "cpu_core": "v5f",
-    "extra_flags": "-DCH32H417RE -DCH32H41X -DCH32H41x -DCH32H417 -DCore_V5F",
+    "extra_flags": "-DCH32H416RD -DCH32H41X -DCH32H41x -DCH32H416",
     "f_cpu": "400000000L",
     "hwids": [
       [
@@ -12,7 +11,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imac_zba_zbb_zbc_zbs_xw",
-    "mcu": "ch32h417reu6",
+    "mcu": "ch32h416rdu6",
     "series": "ch32h417",
     "spl_series": "ch32h417"
   },
@@ -27,10 +26,10 @@
     "noneos-sdk",
     "ch32v003fun"
   ],
-  "name": "Generic CH32H417REU6 (V5F Slave)",
+  "name": "Generic CH32H416RDU6",
   "upload": {
     "maximum_ram_size": 131072,
-    "maximum_size": 983040,
+    "maximum_size": 491520,
     "protocol": "wch-link",
     "protocols": [
       "wch-link",

--- a/boards/genericCH32H416RDU6_V3F.json
+++ b/boards/genericCH32H416RDU6_V3F.json
@@ -2,7 +2,7 @@
   "build": {
     "clock_source": "hsi+pll",
     "cpu_core": "v3f",
-    "extra_flags": "-DCH32H417RE -DCH32H41X -DCH32H41x -DCH32H417 -DCore_V3F",
+    "extra_flags": "-DCH32H416RD -DCH32H41X -DCH32H41x -DCH32H416 -DCore_V3F",
     "f_cpu": "400000000L",
     "hwids": [
       [
@@ -12,7 +12,7 @@
     ],
     "mabi": "ilp32",
     "march": "rv32imac_zba_zbb_zbc_zbs_xw",
-    "mcu": "ch32h417reu6",
+    "mcu": "ch32h416rdu6",
     "series": "ch32h417",
     "spl_series": "ch32h417"
   },
@@ -27,10 +27,10 @@
     "noneos-sdk",
     "ch32v003fun"
   ],
-  "name": "Generic CH32H417REU6 (V3F Master)",
+  "name": "Generic CH32H416RDU6 (V3F Master)",
   "upload": {
     "maximum_ram_size": 131072,
-    "maximum_size": 983040,
+    "maximum_size": 491520,
     "protocol": "wch-link",
     "protocols": [
       "wch-link",

--- a/boards/genericCH32H416RDU6_V5F.json
+++ b/boards/genericCH32H416RDU6_V5F.json
@@ -1,0 +1,44 @@
+{
+  "build": {
+    "clock_source": "hsi+pll",
+    "cpu_core": "v5f",
+    "extra_flags": "-DCH32H416RD -DCH32H41X -DCH32H41x -DCH32H416 -DCore_V5F",
+    "f_cpu": "400000000L",
+    "hwids": [
+      [
+        "0x1A86",
+        "0x8010"
+      ]
+    ],
+    "mabi": "ilp32",
+    "march": "rv32imac_zba_zbb_zbc_zbs_xw",
+    "mcu": "ch32h416rdu6",
+    "series": "ch32h417",
+    "spl_series": "ch32h417"
+  },
+  "debug": {
+    "onboard_tools": [
+      "wch-link"
+    ],
+    "openocd_config": "wch-dual-core.cfg",
+    "svd_path": "CH32H417xx.svd"
+  },
+  "frameworks": [
+    "noneos-sdk",
+    "ch32v003fun"
+  ],
+  "name": "Generic CH32H416RDU6 (V5F Slave)",
+  "upload": {
+    "maximum_ram_size": 131072,
+    "maximum_size": 491520,
+    "protocol": "wch-link",
+    "protocols": [
+      "wch-link",
+      "minichlink",
+      "isp",
+      "wlink"
+    ]
+  },
+  "url": "http://www.wch-ic.com/products/CH32H417.html",
+  "vendor": "W.CH"
+}

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -47,7 +47,7 @@ elif core == "openwch":
     build_script = join(
         env.PioPlatform().get_package_dir("framework-arduino-openwch-ch32"),
         "tools", "platformio-build.py")
-# https://github.com/Community-PIO-CH32V/arduino-core-ch32h4
+# https://github.com/Community-PIO-CH32V/ArduinoCore-CH32H4
 elif core == "ch32h4":
     build_script = join(
         env.PioPlatform().get_package_dir("framework-arduinoch32h4"),

--- a/builder/frameworks/arduino.py
+++ b/builder/frameworks/arduino.py
@@ -47,6 +47,11 @@ elif core == "openwch":
     build_script = join(
         env.PioPlatform().get_package_dir("framework-arduino-openwch-ch32"),
         "tools", "platformio-build.py")
+# https://github.com/Community-PIO-CH32V/arduino-core-ch32h4
+elif core == "ch32h4":
+    build_script = join(
+        env.PioPlatform().get_package_dir("framework-arduinoch32h4"),
+        "tools", "platformio-build.py")
 else:
     sys.stderr.write("Error: Don't know which Arduino core to use for %s!\n" % mcu)
     env.Exit(1)

--- a/builder/main.py
+++ b/builder/main.py
@@ -358,13 +358,6 @@ if access_via_openocd and upload_protocol != "minichlink":
         "Check Flash Protection"
     )
 
-    env.AddPlatformTarget(
-        "erase", None, generate_openocd_action([
-            "-c", "\"flash probe 0\"",
-            "-c", "\"flash erase_sector 0 0 last\"",
-        ], "Erasing Flash"),
-        "Erase Flash"
-    )
 elif upload_protocol == "isp":
     env.AddPlatformTarget(
         "info", None, generate_wchisp_action([
@@ -383,12 +376,6 @@ elif upload_protocol == "isp":
             "config reset"
         ], "Resetting Configuration Registers"),
         "Reset Configuration Registers (ISP)"
-    )
-    env.AddPlatformTarget(
-        "erase", None, generate_wchisp_action([
-            "erase"
-        ], "Erasing Device"),
-        "Erase (ISP)"
     )
     env.AddPlatformTarget(
         "reset", None, generate_wchisp_action([
@@ -433,6 +420,58 @@ if upload_protocol == "wlink" or platform.get_package_dir("tool-wlink") != "":
         ], "Disabling SDI Printf"),
         "Disable SDI Printf (NoneSDK)"
     )
+
+#
+# Target: Erase Flash
+#
+# ONE registration, covering whichever upload method the project uses, so
+# "Erase Flash" is always offered and always means the same thing. It used to
+# be declared separately inside the openocd and the isp branches, which left
+# wlink and minichlink without it; adding two more copies would have meant
+# four places able to disagree, and a duplicate target name where two
+# conditions overlap.
+#
+# espota is the one method with no entry, and cannot have one: it uploads
+# through the sketch already running on the board, so erasing the flash is the
+# one thing it can never do.
+erase_action = None
+erase_label = "Erase Flash"
+
+# THE SELECTED PROTOCOL DECIDES, with one exception below. Erasing with a
+# tool the user has not got attached is no use: somebody uploading over the
+# USB bootloader has no probe, and somebody using a probe may have no
+# bootloader to fall back on.
+if upload_protocol == "wlink":
+    erase_action = generate_wlink_action(["erase"], "Erasing Flash")
+elif upload_protocol == "minichlink":
+    # -E is "Erase chip" in minichlink's own option table.
+    erase_action = generate_minichlink_action(
+        ["-E"], "Erasing Chip", is_minichlink)
+elif upload_protocol == "isp":
+    erase_action = generate_wchisp_action(["erase"], "Erasing Device")
+    erase_label = "Erase Flash (ISP)"
+elif access_via_openocd:
+    if chip_name.startswith("ch32h41"):
+        # THE EXCEPTION, and it is not a preference. An openocd erase on this
+        # part clears only the first 448 KB of the 960 KB user area, so
+        # anything a previous write left above that survives; what boots is
+        # then half old and half new, which presents as a boot loop rather
+        # than as a failed erase. The core's hardware harness erases with
+        # wlink for this reason and warns against mixing the two tools.
+        #
+        # Substituting wlink here is safe because this branch means a debug
+        # probe is already the upload path, and platform.py marks tool-wlink
+        # non-optional for every board, so it is always installed.
+        erase_action = generate_wlink_action(
+            ["erase"], "Erasing Flash (wlink: openocd erases only 448 KB here)")
+    else:
+        erase_action = generate_openocd_action([
+            "-c", "\"flash probe 0\"",
+            "-c", "\"flash erase_sector 0 0 last\"",
+        ], "Erasing Flash")
+
+if erase_action is not None:
+    env.AddPlatformTarget("erase", None, erase_action, erase_label)
 
 #
 # Setup default targets

--- a/builder/main.py
+++ b/builder/main.py
@@ -196,6 +196,61 @@ elif upload_protocol == "wlink":
         UPLOADCMD="$UPLOADER $UPLOADERFLAGS flash $SOURCE",
     )
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
+# Over the air, via the sketch's own ArduinoOTA. Cores that support it ship
+# tools/espota.py and build a *_ota.bin next to the firmware; on the CH32H41x
+# the two differ, because the full binary carries a boot stub that an OTA image
+# must not.
+#
+#     upload_protocol = espota
+#     upload_port = 192.168.1.50      ; or ch32h4-a1b2c3.local
+#     upload_flags = --auth=secret    ; if the sketch sets a password
+#
+# THE SKETCH ON THE BOARD IS PART OF THE UPLOAD PATH: it has to be running and
+# calling ArduinoOTA.handle(). One that hangs or faults takes the network port
+# with it, and the next upload goes over the probe.
+elif upload_protocol == "espota":
+    framework_dir = ""
+    for pkg in ("framework-arduinoch32h4", "framework-arduinoch32v"):
+        try:
+            framework_dir = platform.get_package_dir(pkg) or ""
+        except Exception:
+            framework_dir = ""
+        if framework_dir and os.path.isfile(
+                os.path.join(framework_dir, "tools", "espota.py")):
+            break
+        framework_dir = ""
+    if not framework_dir:
+        sys.stderr.write(
+            "Error: upload_protocol = espota needs a core that ships "
+            "tools/espota.py, and this one does not.\n")
+        env.Exit(1)
+
+    if not env.subst("$UPLOAD_PORT"):
+        sys.stderr.write(
+            "Error: upload_protocol = espota needs upload_port set to the "
+            "board's address or its <name>.local name.\n")
+        env.Exit(1)
+
+    # The OTA image, not the full binary -- but the .bin stays the SCons
+    # target, because the OTA image is written as a side effect of building it
+    # and SCons has no rule that would produce it on its own.
+    #
+    # Resolved when the upload runs rather than now, so that a core which needs
+    # no split (its whole image is the sketch) falls back to the full binary.
+    def _ota_upload(source, target, env):
+        ota = env.subst(os.path.join("$BUILD_DIR", "${PROGNAME}_ota.bin"))
+        if not os.path.isfile(ota):
+            ota = env.subst(os.path.join("$BUILD_DIR", "${PROGNAME}.bin"))
+        return env.Execute(env.VerboseAction(
+            '$UPLOADER $UPLOADERFLAGS -f "%s"' % ota, "Uploading %s" % ota))
+
+    env.Replace(
+        UPLOADER='"$PYTHONEXE" "%s"' % os.path.join(
+            framework_dir, "tools", "espota.py"),
+        UPLOADERFLAGS=["-i", "$UPLOAD_PORT"] + env.get("UPLOAD_FLAGS", []),
+    )
+    upload_target = target_bin
+    upload_actions = [_ota_upload]
 # custom upload tool
 elif upload_protocol == "custom":
     upload_actions = [env.VerboseAction("$UPLOADCMD", "Uploading $SOURCE")]
@@ -382,5 +437,104 @@ if upload_protocol == "wlink" or platform.get_package_dir("tool-wlink") != "":
 #
 # Setup default targets
 #
+
+#
+# Targets: filesystem image (buildfs / uploadfs)
+#
+# Only for cores that reserve a filesystem partition and say where it is. The
+# ch32h4 Arduino core publishes CH32H4_FS_START and CH32H4_FS_SIZE from its own
+# build script, which derives them from the same constants the linker script
+# uses -- so there is exactly one definition of where the partition lives, and
+# an image can never be written over the sketch because two files disagreed.
+#
+# A size of zero means the sketch did not ask for a filesystem, and the targets
+# say so rather than silently building a zero-length image.
+
+fs_size = int(env.get("CH32H4_FS_SIZE", 0) or 0)
+fs_start = int(env.get("CH32H4_FS_START", 0) or 0)
+
+if fs_size > 0 and fs_start > 0:
+    # mklittlefs comes from earlephilhower's package, the same one
+    # platform-raspberrypi uses. Two reasons rather than the registry's
+    # platformio/tool-mklittlefs: that one is the 2021 ESP8266 build, and this
+    # one ships for every host PlatformIO runs on -- windows x86/amd64/arm64,
+    # macOS intel and Apple silicon, and linux x86_64/i686/aarch64/armv6l and
+    # armv7l. The "rp2040" in the name is where it was packaged, not what it
+    # can write; a LittleFS image is defined by the geometry arguments below.
+    #
+    # Resolved to a path, NOT invoked as a bare name. Relying on PATH works
+    # only on a machine that happens to have one installed, and silently picks
+    # up whichever version that is -- and the version decides the on-disk
+    # format.
+    mkfs_dir = platform.get_package_dir("tool-mklittlefs-rp2040-earlephilhower") or ""
+    mkfs_tool = os.path.join(mkfs_dir, "mklittlefs")
+
+    env.Replace(
+        MKFSTOOL=mkfs_tool,
+        # Geometry has to match what the core configures LittleFS with, or the
+        # image mounts as corrupt: 8 KB erase blocks and a 256-byte program
+        # page, which is this part's flash page-program size.
+        FSBLOCKSIZE=int(env.get("CH32H4_FS_BLOCK_SIZE", 8192)),
+        FSPAGESIZE=int(env.get("CH32H4_FS_PAGE_SIZE", 256)),
+    )
+
+    def _mkfs_action(target, source, env):
+        """Everything that should fail with a sentence, not a traceback."""
+        if not mkfs_dir:
+            sys.stderr.write(
+                "Error: tool-mklittlefs-rp2040-earlephilhower is not "
+                "installed, so no filesystem image can be built. It is "
+                "fetched on demand for the buildfs and uploadfs targets; if "
+                "you reached this another way, install it with 'pio pkg "
+                "install -t earlephilhower/"
+                "tool-mklittlefs-rp2040-earlephilhower'.\n")
+            env.Exit(1)
+        data_dir = env.subst("$PROJECT_DATA_DIR")
+        if not os.path.isdir(data_dir):
+            sys.stderr.write(
+                "Error: no data directory at %s. Put the files you want in the"
+                " filesystem there.\n" % data_dir)
+            env.Exit(1)
+        return None
+
+    target_fs_image = os.path.join("$BUILD_DIR", "littlefs.bin")
+
+    fs_image = env.Command(
+        target_fs_image,
+        "$PROJECT_DATA_DIR",
+        [
+            env.VerboseAction(_mkfs_action, None),
+            env.VerboseAction(
+                '"$MKFSTOOL" -c "$SOURCE" -b $FSBLOCKSIZE -p $FSPAGESIZE'
+                ' -s %d "$TARGET"' % fs_size,
+                "Building filesystem image $TARGET"),
+        ],
+    )
+    AlwaysBuild(fs_image)
+
+    env.AddPlatformTarget(
+        "buildfs", fs_image, None, "Build Filesystem Image",
+        "Build a LittleFS image from the data/ directory")
+
+    # Flashed at the partition's own address, NOT at the start of flash. The
+    # sketch is not touched.
+    #
+    # WLINK EXPLICITLY, not $UPLOADER. Two reasons, and the first one alone is
+    # fatal: on this board $UPLOADER is openocd, which does not take "flash
+    # --address" and fails with "unknown option -- address". And even with the
+    # right syntax openocd cannot program the upper flash, which is precisely
+    # where a filesystem partition lives -- 0x080CC000 for a 128 KB one. wlink
+    # is the tool that can write it, which is why the hardware harness uses it
+    # for everything.
+    wlink = os.path.join(platform.get_package_dir("tool-wlink") or "", "wlink")
+
+    env.AddPlatformTarget(
+        "uploadfs", fs_image,
+        [env.VerboseAction(
+            '"%s" flash --address 0x%08X "$SOURCE"' % (wlink, fs_start),
+            "Uploading filesystem image to 0x%08X" % fs_start)],
+        "Upload Filesystem Image",
+        "Write the LittleFS image into the flash partition")
+
 
 Default([target_buildprog, target_size])

--- a/examples/blinky-none-os/platformio.ini
+++ b/examples/blinky-none-os/platformio.ini
@@ -89,3 +89,12 @@ board = genericCH32L103C8T6
 
 [env:genericCH32H417QEU6_V3F]
 board = genericCH32H417QEU6_V3F
+
+; The other two CH32H41x series. Both are QFN60 parts, and the difference that
+; matters here is flash: the CH32H416RDU6 has 480K where the rest of the family
+; has 960K.
+[env:genericCH32H416RDU6_V3F]
+board = genericCH32H416RDU6_V3F
+
+[env:genericCH32H415REU6_V3F]
+board = genericCH32H415REU6_V3F

--- a/misc/scripts/gen_boarddefs.py
+++ b/misc/scripts/gen_boarddefs.py
@@ -107,6 +107,13 @@ class ChipInfo:
         # Hack: A ch32v317 uses the same SDK as the ch32v307.
         if self.name.lower().startswith("ch32v317"):
             return "ch32v307"
+        # Hack: the whole CH32H41x family is one SDK series. The vendor ships
+        # Core/ch32h417, System/ch32h417 and startup_ch32h417_v3f.S with no
+        # ch32h415 or ch32h416 counterpart, so a CH32H416RDU6 that asked for
+        # its own series would fail looking for a startup file that does not
+        # exist.
+        if self.name.lower().startswith("ch32h41"):
+            return "ch32h417"
         # CH32V407/CH32V467 share the "ch32v4x7" SDK series naming.
         if self.name.lower().startswith("ch32v407") or self.name.lower().startswith("ch32v467"):
             return "ch32v4x7"
@@ -259,11 +266,20 @@ chip_db: List[ChipInfo] = [
     ChipInfo("CH32L103G8R6", 64, 20, 96, "QSOP28", CH32L103),
     ChipInfo("CH32L103K8U6", 64, 20, 96, "QFN32", CH32L103),
     ChipInfo("CH32L103C8T6", 64, 20, 96, "LQFP48", CH32L103),
-    # CH32H417 (960K nonzero-wait-state flash), 960 SRAM, 400 MHz V5F, 150 MHz on V3F  
+    # CH32H41x (960K nonzero-wait-state flash), 400 MHz V5F, 100 MHz on V3F.
+    #
+    # Five parts, from the "Resource differences" table of the datasheet
+    # (CH32H417DS0, section 1) and the family list at
+    # https://www.wch-ic.com/products/CH32H417.html. The part numbers change
+    # with the series, not just the package: REU6 is a CH32H415 and RDU6 is a
+    # CH32H416. There is no CH32H417REU6, which this list used to claim.
+    #
+    # CH32H416RDU6 is the one with less flash: 480K where the rest have 960K.
     ChipInfo("CH32H417QEU6", 960, 128, 400, "QFN128", CH32H417),
     ChipInfo("CH32H417MEU6", 960, 128, 400, "QFN88", CH32H417),
     ChipInfo("CH32H417WEU6", 960, 128, 400, "QFN68", CH32H417),
-    ChipInfo("CH32H417REU6", 960, 128, 400, "QFN60X6", CH32H417),
+    ChipInfo("CH32H416RDU6", 480, 128, 400, "QFN60X6", CH32H417),
+    ChipInfo("CH32H415REU6", 960, 128, 400, "QFN60X6", CH32H417),
 ]
 
 def get_chip(name: str) -> Optional[ChipInfo]:

--- a/platform.json
+++ b/platform.json
@@ -128,7 +128,7 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": "https://github.com/Community-PIO-CH32V/arduino-core-ch32h4.git"
+      "version": "https://github.com/Community-PIO-CH32V/ArduinoCore-CH32H4.git"
     },
     "framework-ch32v003fun": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -189,6 +189,12 @@
       "optional": true,
       "owner": "platformio",
       "version": "^3.0.0"
+    },
+    "tool-mklittlefs-rp2040-earlephilhower": {
+      "type": "uploader",
+      "optional": true,
+      "owner": "earlephilhower",
+      "version": "~5.100300.0"
     }
   }
 }

--- a/platform.json
+++ b/platform.json
@@ -167,7 +167,7 @@
     "tool-wlink": {
       "type": "uploader",
       "owner": "community-ch32v",
-      "version": "https://github.com/Community-PIO-CH32V/tool-wlink.git#windows",
+      "version": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-windows",
       "optional": false
     },
     "tool-cmake": {

--- a/platform.json
+++ b/platform.json
@@ -124,6 +124,12 @@
       "owner": "platformio",
       "version": "https://github.com/Community-PIO-CH32V/arduino_core_ch32.git"
     },
+    "framework-arduinoch32h4": {
+      "type": "framework",
+      "optional": true,
+      "owner": "platformio",
+      "version": "https://github.com/Community-PIO-CH32V/arduino-core-ch32h4.git"
+    },
     "framework-ch32v003fun": {
       "type": "framework",
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -144,6 +144,11 @@ class Ch32vPlatform(PlatformBase):
                 self.frameworks["arduino"]["package"] = "framework-arduinoch32v"
             elif build_core == "openwch":
                self.frameworks["arduino"]["package"] = "framework-arduino-openwch-ch32"
+            elif build_core == "ch32h4":
+                # The CH32H4 core. Without this case the board fell through to
+                # the framework's default package, the CH32V003 core, and the
+                # builder then found no framework-arduinoch32h4 to build.
+                self.frameworks["arduino"]["package"] = "framework-arduinoch32h4"
         if "zephyr" in frameworks:
             for p in self.packages:
                 if p in ("tool-cmake", "tool-dtc", "tool-ninja"):

--- a/platform.py
+++ b/platform.py
@@ -51,20 +51,37 @@ class Ch32vPlatform(PlatformBase):
         "darwin_x86_64": "https://github.com/Community-PIO-CH32V/tool-minichlink.git#mac",
         "darwin_arm64": "https://github.com/Community-PIO-CH32V/tool-minichlink.git#mac_arm64"
     }
+    # PINNED TO A TAG, NOT A BRANCH -- and the version in the tag name is the
+    # reason. PlatformIO installs a VCS package once and keys it by this exact
+    # string, so a branch name never changes and an existing installation
+    # keeps whatever binary it cloned. Everyone who had this platform before
+    # would have stayed on wlink 0.1.1, which reports "Probe is not attached to
+    # an MCU" on the CH32H41x and cannot program it at all. Changing the string
+    # is what makes the next build fetch the new tool.
+    #
+    # A tag rather than a commit id: PlatformIO shallow-clones a branch or tag
+    # (--depth 1 --branch <tag>) but does a FULL clone for a commit id, and
+    # this repo's master branch carries every package tarball ever built --
+    # about 15 MB of history to download for a 1 MB tool.
+    #
+    # Updating: push the new binaries to the OS branches, tag each one
+    # 0.<minor>.<datecode>-<branch>, and bump the four lines below.
     wlink_tool = {
-        # Windows
-        "windows_amd64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#windows",
-        "windows_x86": "https://github.com/Community-PIO-CH32V/tool-wlink.git#windows",
+        # Windows. Both systypes get the x86 build: the x64 build of 0.1.2
+        # fails with a driver error on Windows, and x86 works against the WCH
+        # drivers as well.
+        "windows_amd64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-windows",
+        "windows_x86": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-windows",
         # No Windows ARM64 or ARM32 builds.
         # Linux
-        "linux_x86_64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#linux",
+        "linux_x86_64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-linux",
         #"linux_i686": "",
         #"linux_aarch64": "",
         #"linux_armv7l": "",
         #"linux_armv6l": "",
         # Mac (Intel and ARM are separate)
-        "darwin_x86_64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#mac_x64",
-        "darwin_arm64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#mac_arm64"
+        "darwin_x86_64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-mac_x64",
+        "darwin_arm64": "https://github.com/Community-PIO-CH32V/tool-wlink.git#0.23.260911-mac_arm64"
     }
 
     def get_boards(self, id_=None):

--- a/platform.py
+++ b/platform.py
@@ -126,8 +126,16 @@ class Ch32vPlatform(PlatformBase):
             self.packages["tool-minichlink"]["version"] = Ch32vPlatform.minichlink_tool[sys_type]
         #elif variables.get("upload_protocol", default_protocol) == "wlink":
         # Always update the link to the tool-wlink tool, because for all uploads we want to have the "Enable SDI Print" available
-        self.packages["tool-wlink"]["optional"] = False        
+        self.packages["tool-wlink"]["optional"] = False
         self.packages["tool-wlink"]["version"] = Ch32vPlatform.wlink_tool[sys_type]
+        # mklittlefs, only when a filesystem image is actually being built.
+        # Leaving it optional otherwise means the great majority of builds,
+        # which have no data/ directory, never download it.
+        #
+        # uploadfs is listed as well as buildfs because it depends on the
+        # image, so it needs the tool that makes one.
+        if any(t in targets for t in ("buildfs", "uploadfs")):
+            self.packages["tool-mklittlefs-rp2040-earlephilhower"]["optional"] = False
         build_core = variables.get("board_build.core", board_config.get("build.core", "arduino"))
         if "arduino" in frameworks:
             if build_core == "ch32v003":


### PR DESCRIPTION
Adds PlatformIO support for the CH32H4 Arduino core ([Community-PIO-CH32V/ArduinoCore-CH32H4](https://github.com/Community-PIO-CH32V/ArduinoCore-CH32H4)) and updates the CH32H41x part list.

## What changes

- **`ch32h417qeu6_evt_r0` board** with `framework = arduino`, using the core's `CH32H417QEU6_EVT_R0` variant.
- **`framework-arduinoch32h4`** in `platform.json`, fetched from the core's public repository, and selected in `platform.py` for boards with `build.core = ch32h4`.
- **`tool-wlink` pinned to the CH32H4-capable `0.23.260911` tags** per OS. The older wlink reports "Probe is not attached to an MCU" on the CH32H41x. The spec strings are version tags, because PlatformIO keys VCS packages by spec string and would otherwise keep a stale install.
- **Filesystem and OTA targets**, with `mklittlefs` from earlephilhower's registry package, installed only when a filesystem image is built.
- **"Erase Flash"** for every upload method that can do it.
- **Part list fixed:** there is no CH32H417REU6. The QFN60 parts are the CH32H415REU6 and the CH32H416RDU6, which has 480K flash. Boards generated with `misc/scripts/gen_boarddefs.py`, and both added to the `blinky-none-os` example.

## Testing

The core's hardware test suite ran against this branch on a CH32H417QEU6 EVT board throughout development. Every one of those builds named the core explicitly with `platform_packages = framework-arduinoch32h4 @ symlink://...`, which hid two install-path bugs. Both were found by a clean install from GitHub while preparing this PR, and both are fixed here:

- **Wrong repository URL.** `platform.json` pointed at `Community-PIO-CH32V/arduino-core-ch32h4`, which does not exist. It now points at `ArduinoCore-CH32H4`.
- **Wrong core installed.** `configure_default_packages()` had no `ch32h4` case, so the EVT board fell through to the Arduino framework's default package, the CH32V003 core, and the builder found no `framework-arduinoch32h4` to build.

A clean-install build of an Arduino sketch for the EVT board, in a fresh PlatformIO home with no local packages, is the acceptance check for merging.

CI's example matrix covers the SDK examples for the H41x parts but has no Arduino example for the H4 core, so CI does not exercise the Arduino path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwRqfix3zqKNJy2o4pQwvV
